### PR TITLE
fix crash when 'payable' nil

### DIFF
--- a/Sources/web3swift/EthereumABI/ABIParsing.swift
+++ b/Sources/web3swift/EthereumABI/ABIParsing.swift
@@ -82,7 +82,7 @@ fileprivate func parseFunction(abiRecord:ABI.Record) throws -> ABI.Element.Funct
 }
 
 fileprivate func parseFallback(abiRecord:ABI.Record) throws -> ABI.Element.Fallback {
-    let payable = (abiRecord.stateMutability == "payable" || abiRecord.payable!)
+    let payable = (abiRecord.stateMutability == "payable" || abiRecord.payable == true)
     var constant = abiRecord.constant == true
     if (abiRecord.stateMutability == "view" || abiRecord.stateMutability == "pure") {
         constant = true


### PR DESCRIPTION
Fix crash when parsing custom ABI Contract

fix #333 