### PR TITLE
Added: Receive type at ABI.Element

### DIFF
--- a/Sources/web3swift/EthereumABI/ABIElements.swift
+++ b/Sources/web3swift/EthereumABI/ABIElements.swift
@@ -43,6 +43,7 @@ public extension ABI {
         case constructor(Constructor)
         case fallback(Fallback)
         case event(Event)
+        case receive(Receive)
         
         public enum StateMutability {
             case payable
@@ -142,6 +143,15 @@ public extension ABI {
                 }
             }
         }
+        public struct Receive {
+            public let payable: Bool
+            public let inputs: [InOut]
+            
+            public init(inputs: [InOut], payable: Bool) {
+                self.inputs = inputs
+                self.payable = payable
+            }
+        }
     }
 }
 
@@ -161,6 +171,8 @@ extension ABI.Element {
             let signature = function.methodEncoding
             guard let data = ABIEncoder.encode(types: function.inputs, values: parameters) else {return nil}
             return signature + data
+        case .receive(_):
+            return nil
         }
     }
 }
@@ -199,6 +211,8 @@ extension ABI.Element {
                 i = i + 1
             }
             return returnArray
+        case .receive(_):
+            return nil
         }
     }
     
@@ -272,6 +286,8 @@ extension ABI.Element {
                 i = i + 1
             }
             return returnArray
+        case .receive(_):
+            return nil
         }
     }
 }

--- a/Sources/web3swift/EthereumABI/ABIParsing.swift
+++ b/Sources/web3swift/EthereumABI/ABIParsing.swift
@@ -30,6 +30,7 @@ extension ABI {
         case constructor
         case fallback
         case event
+        case receive
     }
     
 }
@@ -58,6 +59,9 @@ fileprivate func parseToElement(from abiRecord: ABI.Record, type: ABI.ElementTyp
     case .event:
         let event = try parseEvent(abiRecord: abiRecord)
         return ABI.Element.event(event)
+    case .receive:
+        let receive = try parseReceive(abiRecord: abiRecord)
+        return ABI.Element.receive(receive)
     }
     
 }
@@ -118,6 +122,23 @@ fileprivate func parseEvent(abiRecord:ABI.Record) throws -> ABI.Element.Event {
     let name = abiRecord.name != nil ? abiRecord.name! : ""
     let anonymous = abiRecord.anonymous != nil ? abiRecord.anonymous! : false
     let functionElement = ABI.Element.Event(name: name, inputs: abiInputs, anonymous: anonymous)
+    return functionElement
+}
+
+fileprivate func parseReceive(abiRecord:ABI.Record) throws -> ABI.Element.Receive {
+    let inputs = try abiRecord.inputs?.map({ (input:ABI.Input) throws -> ABI.Element.InOut in
+        let nativeInput = try input.parse()
+        return nativeInput
+    })
+    let abiInputs = inputs != nil ? inputs! : [ABI.Element.InOut]()
+    var payable = false
+    if (abiRecord.payable != nil) {
+        payable = abiRecord.payable!
+    }
+    if (abiRecord.stateMutability == "payable") {
+        payable = true
+    }
+    let functionElement = ABI.Element.Receive(inputs: abiInputs, payable: payable)
     return functionElement
 }
 


### PR DESCRIPTION
Added a new type of ABI.Element called **receive**. This ABI element, when present in a contract, indicates that the contract allows to receive tokens through a function call.

Fixes #342 