### PR TITLE
fixed parsing of ABIs with tuples + wrong gas info when transactionOptions created from json

### DIFF
--- a/Sources/web3swift/EthereumABI/ABIDecoding.swift
+++ b/Sources/web3swift/EthereumABI/ABIDecoding.swift
@@ -137,7 +137,12 @@ extension ABIDecoder {
                         let (v, c) = decodeSignleType(type: subType, data: dataSlice, pointer: subpointer)
                         guard let valueUnwrapped = v, let consumedUnwrapped = c else {break}
                         toReturn.append(valueUnwrapped)
-                        subpointer = subpointer + consumedUnwrapped
+                        if (subType.isStatic) {
+                            subpointer = subpointer + consumedUnwrapped
+                        }
+                        else {
+                            subpointer = consumedUnwrapped // need to go by nextElementPointer
+                        }
                     }
                     return (toReturn as AnyObject, nextElementPointer)
                 }

--- a/Sources/web3swift/EthereumABI/ABIParameterTypes.swift
+++ b/Sources/web3swift/EthereumABI/ABIParameterTypes.swift
@@ -220,7 +220,7 @@ extension ABI.Element.ParameterType: ABIEncoding {
         case .tuple(types: let types):
             let typesRepresentation = types.map({return $0.abiRepresentation})
             let typesJoined = typesRepresentation.joined(separator: ",")
-            return "tuple(\(typesJoined))"
+            return "(\(typesJoined))"
         case .string:
             return "string"
         }

--- a/Sources/web3swift/EthereumABI/ABIParsing.swift
+++ b/Sources/web3swift/EthereumABI/ABIParsing.swift
@@ -134,6 +134,17 @@ extension ABI.Input {
             let nativeInput = ABI.Element.InOut(name: name, type: type)
             return nativeInput
         }
+        else if case .array(type: .tuple(types: _), length: _) = parameterType {
+            let components = try self.components?.compactMap({ (inp: ABI.Input) throws -> ABI.Element.ParameterType in
+                let input = try inp.parse()
+                return input.type
+            })
+            let tupleType = ABI.Element.ParameterType.tuple(types: components!)
+            
+            let newType: ABI.Element.ParameterType = .array(type: tupleType, length: 0)
+            let nativeInput = ABI.Element.InOut(name: name, type: newType)
+            return nativeInput
+        }
         else {
             let nativeInput = ABI.Element.InOut(name: name, type: parameterType)
             return nativeInput

--- a/Sources/web3swift/Web3/Web3+Options.swift
+++ b/Sources/web3swift/Web3/Web3+Options.swift
@@ -125,7 +125,7 @@ public struct TransactionOptions {
     public static func fromJSON(_ json: [String: Any]) -> TransactionOptions? {
         var options = TransactionOptions()
         if let gas = json["gas"] as? String, let gasBiguint = BigUInt(gas.stripHexPrefix().lowercased(), radix: 16) {
-            options.gasLimit = .limited(gasBiguint)
+            options.gasLimit = .manual(gasBiguint)
         } else if let gasLimit = json["gasLimit"] as? String, let gasgasLimitBiguint = BigUInt(gasLimit.stripHexPrefix().lowercased(), radix: 16) {
             options.gasLimit = .limited(gasgasLimitBiguint)
         } else {


### PR DESCRIPTION
related to the issues #358 (https://github.com/skywinder/web3swift/issues/358)
and #353 https://github.com/skywinder/web3swift/issues/353