### PR TITLE
podspec 2.3.1

### DIFF
--- a/web3swift.podspec
+++ b/web3swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = 'web3swift'
-    spec.version      = '2.3.0'
+    spec.version      = '2.3.1'
     spec.ios.deployment_target = "9.0"
     spec.osx.deployment_target = "10.11"
     spec.license      = { :type => 'Apache License 2.0', :file => 'LICENSE.md' }
@@ -13,9 +13,9 @@ Pod::Spec.new do |spec|
     spec.resource_bundle = { "Browser" => "Sources/web3swift/Browser/*.js" }
     spec.swift_version = '5.0'
     spec.frameworks = 'CoreImage'
-    spec.dependency 'BigInt', '~> 5.2'
+    spec.dependency 'BigInt', '~> 5.3.0'
     spec.dependency 'Starscream', '~> 4.0.4'
-    spec.dependency 'CryptoSwift', '~> 1.4.0'
+    spec.dependency 'CryptoSwift', '~> 1.4.2'
     spec.dependency 'secp256k1.c', '~> 0.1'
     spec.dependency 'PromiseKit', '~> 6.15.3'
 end


### PR DESCRIPTION
'exported: true' has no effect in '_specialize' attribute #384

PromiseKit and BigInt updates not yet reflected in their Podspecs