### PR TITLE
Provide basic tolerance to EIP-1559 data

### DIFF
--- a/Sources/web3swift/Transaction/EthereumTransaction.swift
+++ b/Sources/web3swift/Transaction/EthereumTransaction.swift
@@ -125,10 +125,10 @@ public struct EthereumTransaction: CustomStringConvertible {
         } else if self.v >= 27 && self.v <= 30 {
             d = BigUInt(27)
         }
-        if (self.chainID != nil && self.chainID != BigUInt(0) && self.v >= (d + self.chainID! + self.chainID!)) {
-            normalizedV = self.v - d - self.chainID! - self.chainID!
-        } else if (inferedChainID != nil  && self.v >= (d + self.inferedChainID! + self.inferedChainID!)) {
-            normalizedV = self.v - d - inferedChainID! - inferedChainID!
+        if let testID = self.chainID, testID != BigUInt(0) && self.v >= (d + testID + testID) {
+            normalizedV = self.v - d - testID - testID
+        } else if let testID = inferedChainID, self.v >= (d + testID + testID) {
+            normalizedV = self.v - d - testID - testID
         } else {
             if(d > v) { d = 0 }
             normalizedV = self.v - d

--- a/Sources/web3swift/Transaction/EthereumTransaction.swift
+++ b/Sources/web3swift/Transaction/EthereumTransaction.swift
@@ -29,7 +29,7 @@ public struct EthereumTransaction: CustomStringConvertible {
         get{
             if (self.r == BigUInt(0) && self.s == BigUInt(0)) {
                 return self.v
-            } else if (self.v == BigUInt(27) || self.v == BigUInt(28)) {
+            } else if (self.v == BigUInt(27) || self.v == BigUInt(28) || self.v < BigUInt(35)) {
                 return nil
             } else {
                 return ((self.v - BigUInt(1)) / BigUInt(2)) - BigUInt(17)
@@ -125,11 +125,12 @@ public struct EthereumTransaction: CustomStringConvertible {
         } else if self.v >= 27 && self.v <= 30 {
             d = BigUInt(27)
         }
-        if (self.chainID != nil && self.chainID != BigUInt(0)) {
+        if (self.chainID != nil && self.chainID != BigUInt(0) && self.v >= (d + self.chainID! + self.chainID!)) {
             normalizedV = self.v - d - self.chainID! - self.chainID!
-        } else if (inferedChainID != nil) {
+        } else if (inferedChainID != nil  && self.v >= (d + self.inferedChainID! + self.inferedChainID!)) {
             normalizedV = self.v - d - inferedChainID! - inferedChainID!
         } else {
+            if(d > v) { d = 0 }
             normalizedV = self.v - d
         }
         guard let vData = normalizedV.serialize().setLengthLeft(1) else {return nil}

--- a/Sources/web3swift/Web3/Web3+Structures.swift
+++ b/Sources/web3swift/Web3/Web3+Structures.swift
@@ -110,12 +110,20 @@ extension EthereumTransaction:Decodable {
         case r
         case s
         case value
+        case type  // present in EIP-1559 transaction objects
     }
     
     public init(from decoder: Decoder) throws {
         let options = try TransactionOptions(from: decoder)
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
+        // test to see if it is a EIP-1559 wrapper
+        let envelope = try decodeHexToBigUInt(container, key: .type, allowOptional: true)
+        if( (envelope != nil) && (envelope! != BigInt(0)) ) {
+            // if present and non-sero we are a new wrapper we can't decode
+            throw Web3Error.dataError
+        }
+
         var data = try decodeHexToData(container, key: .data, allowOptional: true)
         if data != nil {
             self.data = data!

--- a/Sources/web3swift/Web3/Web3+Structures.swift
+++ b/Sources/web3swift/Web3/Web3+Structures.swift
@@ -118,12 +118,11 @@ extension EthereumTransaction:Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         // test to see if it is a EIP-1559 wrapper
-        let envelope = try decodeHexToBigUInt(container, key: .type, allowOptional: true)
-        if( (envelope != nil) && (envelope! != BigInt(0)) ) {
+        if let envelope = try decodeHexToBigUInt(container, key: .type, allowOptional: true) {
             // if present and non-sero we are a new wrapper we can't decode
-            throw Web3Error.dataError
+            if(envelope != BigInt(0)) { throw Web3Error.dataError }
         }
-
+        
         var data = try decodeHexToData(container, key: .data, allowOptional: true)
         if data != nil {
             self.data = data!


### PR DESCRIPTION
Provides some basic tolerance if a EIP-1559 [or future] unknown envelope is encountered. Decoding is abandoned if the field type is present and not 0. Otherwise if 0 or not present decoding is allowed as it is a legacy encoding.

Also included are some range checks at specific places to prevent the overflow condition from happening that results in the precondition trigger in the BigUInt library from halting execution. The result of the subsequent calculation will be incorrect, but the data going in was incorrect anyway... at least it doesn't crash.

fixes #463