### PR TITLE
Fix tokenURI method name for ERC721 and ERC721x tokens

### DIFF
--- a/Sources/web3swift/Tokens/ERC721/Web3+ERC721.swift
+++ b/Sources/web3swift/Tokens/ERC721/Web3+ERC721.swift
@@ -272,7 +272,7 @@ extension ERC721: IERC721Metadata {
         let contract = self.contract
         var transactionOptions = TransactionOptions()
         transactionOptions.callOnBlock = .latest
-        let result = try contract.read("tokenId", parameters: [tokenId] as [AnyObject], extraData: Data(), transactionOptions: self.transactionOptions)!.call(transactionOptions: transactionOptions)
+        let result = try contract.read("tokenURI", parameters: [tokenId] as [AnyObject], extraData: Data(), transactionOptions: self.transactionOptions)!.call(transactionOptions: transactionOptions)
         guard let res = result["0"] as? String else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
         return res
     }

--- a/Sources/web3swift/Tokens/ERC721x/Web3+ERC721x.swift
+++ b/Sources/web3swift/Tokens/ERC721x/Web3+ERC721x.swift
@@ -248,7 +248,7 @@ public class ERC721x: IERC721x {
         let contract = self.contract
         var transactionOptions = TransactionOptions()
         transactionOptions.callOnBlock = .latest
-        let result = try contract.read("tokenId", parameters: [tokenId] as [AnyObject], extraData: Data(), transactionOptions: self.transactionOptions)!.call(transactionOptions: transactionOptions)
+        let result = try contract.read("tokenURI", parameters: [tokenId] as [AnyObject], extraData: Data(), transactionOptions: self.transactionOptions)!.call(transactionOptions: transactionOptions)
         guard let res = result["0"] as? String else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
         return res
     }


### PR DESCRIPTION
Change method name used in `tokenURI(tokenId:)` from *"tokenId"* to *"tokenURI"* for both `ERC721` and `ERC721x` tokens.

Fixes #419