### PR TITLE
Fix for transactionIndex incorrectly returning blockNumber

### DIFF
--- a/Sources/web3swift/Web3/Web3+Structures.swift
+++ b/Sources/web3swift/Web3/Web3+Structures.swift
@@ -192,7 +192,7 @@ public struct TransactionDetails: Decodable {
         let blockHash = try decodeHexToData(container, key: .blockHash, allowOptional: true)
         self.blockHash = blockHash
         
-        let transactionIndex = try decodeHexToBigUInt(container, key: .blockNumber, allowOptional: true)
+        let transactionIndex = try decodeHexToBigUInt(container, key: .transactionIndex, allowOptional: true)
         self.transactionIndex = transactionIndex
         
         let transaction = try EthereumTransaction(from: decoder)


### PR DESCRIPTION
TransactionDetails was incorrectly returning blockNumber as transactionIndex. Corrected the property key to return the correct value.

fixes #464

[re-submit as the previous one got corrupted]
