### PR TITLE
Remove dead JSON code

### DIFF
--- a/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
+++ b/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
@@ -71,20 +71,7 @@ extension web3.BrowserFunctions {
         guard let publicKey = SECP256K1.recoverPublicKey(hash: hash, signature: signatureData) else {return nil}
         return Web3.Utils.publicToAddressString(publicKey)
     }
-    
-    
-    public func sendTransaction(_ transactionJSON: [String: Any], password: String = "web3swift") -> [String:Any]? {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
-        var transactionOptions = TransactionOptions()
-        transactionOptions.from = options.from
-        transactionOptions.to = options.to
-        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-        transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
-        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
-        return self.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
-    }
-    
+
     public func sendTransaction(_ transaction: EthereumTransaction, transactionOptions: TransactionOptions, password: String = "web3swift") -> [String:Any]? {
         do {
             let result = try self.web3.eth.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
@@ -93,35 +80,13 @@ extension web3.BrowserFunctions {
             return nil
         }
     }
-    
-    public func estimateGas(_ transactionJSON: [String: Any]) -> BigUInt? {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
-        var transactionOptions = TransactionOptions()
-        transactionOptions.from = options.from
-        transactionOptions.to = options.to
-        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-        transactionOptions.gasLimit = .automatic
-        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
-        return self.estimateGas(transaction, transactionOptions: transactionOptions)
-    }
-    
+
     public func estimateGas(_ transaction: EthereumTransaction, transactionOptions: TransactionOptions) -> BigUInt? {
         do {
             let result = try self.web3.eth.estimateGas(transaction, transactionOptions: transactionOptions)
             return result
         } catch {
             return nil
-        }
-    }
-    
-    public func prepareTxForApproval(_ transactionJSON: [String: Any]) -> (transaction: EthereumTransaction?, options: TransactionOptions?) {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return (nil, nil)}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return (nil, nil)}
-        do {
-            return try self.prepareTxForApproval(transaction, options: options)
-        } catch {
-            return (nil, nil)
         }
     }
 
@@ -142,24 +107,7 @@ extension web3.BrowserFunctions {
             return (nil, nil)
         }
     }
-    
-    public func signTransaction(_ transactionJSON: [String: Any], password: String = "web3swift") -> String? {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
-        var transactionOptions = TransactionOptions()
-        transactionOptions.from = options.from
-        transactionOptions.to = options.to
-        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-        transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
-        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
-        if let nonceString = transactionJSON["nonce"] as? String, let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) {
-            transactionOptions.nonce = .manual(nonce)
-        } else {
-            transactionOptions.nonce = .pending
-        }
-        return self.signTransaction(transaction, transactionOptions: transactionOptions, password: password)
-    }
-    
+
     public func signTransaction(_ trans: EthereumTransaction, transactionOptions: TransactionOptions, password: String = "web3swift") -> String? {
         do {
             var transaction = trans

--- a/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
+++ b/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
@@ -81,7 +81,7 @@ extension web3.BrowserFunctions {
           var transactionOptions = TransactionOptions()
           transactionOptions.from = options.from
           transactionOptions.to = options.to
-          transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+          transactionOptions.value = options.value ?? 0
           transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
           transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
           return self.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)

--- a/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
+++ b/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
@@ -82,8 +82,8 @@ extension web3.BrowserFunctions {
           transactionOptions.from = options.from
           transactionOptions.to = options.to
           transactionOptions.value = options.value ?? 0
-          transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
-          transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+          transactionOptions.gasLimit = options.gasLimit ?? .automatic
+          transactionOptions.gasPrice = options.gasPrice ?? .automatic
           return self.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
         } catch { return nil }
     }
@@ -105,9 +105,9 @@ extension web3.BrowserFunctions {
             var transactionOptions = TransactionOptions()
             transactionOptions.from = options.from
             transactionOptions.to = options.to
-            transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+            transactionOptions.value = options.value ?? 0
             transactionOptions.gasLimit = .automatic
-            transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+            transactionOptions.gasPrice = options.gasPrice ?? .automatic
             return self.estimateGas(transaction, transactionOptions: transactionOptions)
         } catch { return nil }
     }
@@ -158,9 +158,9 @@ extension web3.BrowserFunctions {
             var transactionOptions = TransactionOptions()
             transactionOptions.from = options.from
             transactionOptions.to = options.to
-            transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-            transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
-            transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+            transactionOptions.value = options.value ?? 0
+            transactionOptions.gasLimit = options.gasLimit ?? .automatic
+            transactionOptions.gasPrice = options.gasPrice ?? .automatic
             if let nonceString = transactionJSON["nonce"] as? String, let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) {
                 transactionOptions.nonce = .manual(nonce)
             } else {

--- a/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
+++ b/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
@@ -71,7 +71,20 @@ extension web3.BrowserFunctions {
         guard let publicKey = SECP256K1.recoverPublicKey(hash: hash, signature: signatureData) else {return nil}
         return Web3.Utils.publicToAddressString(publicKey)
     }
-
+    
+    
+    public func sendTransaction(_ transactionJSON: [String: Any], password: String = "web3swift") -> [String:Any]? {
+        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
+        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
+        var transactionOptions = TransactionOptions()
+        transactionOptions.from = options.from
+        transactionOptions.to = options.to
+        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+        transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
+        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+        return self.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
+    }
+    
     public func sendTransaction(_ transaction: EthereumTransaction, transactionOptions: TransactionOptions, password: String = "web3swift") -> [String:Any]? {
         do {
             let result = try self.web3.eth.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
@@ -80,13 +93,35 @@ extension web3.BrowserFunctions {
             return nil
         }
     }
-
+    
+    public func estimateGas(_ transactionJSON: [String: Any]) -> BigUInt? {
+        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
+        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
+        var transactionOptions = TransactionOptions()
+        transactionOptions.from = options.from
+        transactionOptions.to = options.to
+        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+        transactionOptions.gasLimit = .automatic
+        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+        return self.estimateGas(transaction, transactionOptions: transactionOptions)
+    }
+    
     public func estimateGas(_ transaction: EthereumTransaction, transactionOptions: TransactionOptions) -> BigUInt? {
         do {
             let result = try self.web3.eth.estimateGas(transaction, transactionOptions: transactionOptions)
             return result
         } catch {
             return nil
+        }
+    }
+    
+    public func prepareTxForApproval(_ transactionJSON: [String: Any]) -> (transaction: EthereumTransaction?, options: TransactionOptions?) {
+        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return (nil, nil)}
+        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return (nil, nil)}
+        do {
+            return try self.prepareTxForApproval(transaction, options: options)
+        } catch {
+            return (nil, nil)
         }
     }
 
@@ -107,7 +142,24 @@ extension web3.BrowserFunctions {
             return (nil, nil)
         }
     }
-
+    
+    public func signTransaction(_ transactionJSON: [String: Any], password: String = "web3swift") -> String? {
+        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
+        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
+        var transactionOptions = TransactionOptions()
+        transactionOptions.from = options.from
+        transactionOptions.to = options.to
+        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+        transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
+        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+        if let nonceString = transactionJSON["nonce"] as? String, let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) {
+            transactionOptions.nonce = .manual(nonce)
+        } else {
+            transactionOptions.nonce = .pending
+        }
+        return self.signTransaction(transaction, transactionOptions: transactionOptions, password: password)
+    }
+    
     public func signTransaction(_ trans: EthereumTransaction, transactionOptions: TransactionOptions, password: String = "web3swift") -> String? {
         do {
             var transaction = trans

--- a/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
+++ b/Sources/web3swift/HookedFunctions/Web3+BrowserFunctions.swift
@@ -74,15 +74,18 @@ extension web3.BrowserFunctions {
     
     
     public func sendTransaction(_ transactionJSON: [String: Any], password: String = "web3swift") -> [String:Any]? {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
-        var transactionOptions = TransactionOptions()
-        transactionOptions.from = options.from
-        transactionOptions.to = options.to
-        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-        transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
-        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
-        return self.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
+        do {
+          let jsonData: Data = try JSONSerialization.data(withJSONObject: transactionJSON, options: [])
+          let transaction: EthereumTransaction = try JSONDecoder().decode(EthereumTransaction.self, from: jsonData)
+          let options: TransactionOptions = try JSONDecoder().decode(TransactionOptions.self, from: jsonData)
+          var transactionOptions = TransactionOptions()
+          transactionOptions.from = options.from
+          transactionOptions.to = options.to
+          transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+          transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
+          transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+          return self.sendTransaction(transaction, transactionOptions: transactionOptions, password: password)
+        } catch { return nil }
     }
     
     public func sendTransaction(_ transaction: EthereumTransaction, transactionOptions: TransactionOptions, password: String = "web3swift") -> [String:Any]? {
@@ -95,15 +98,18 @@ extension web3.BrowserFunctions {
     }
     
     public func estimateGas(_ transactionJSON: [String: Any]) -> BigUInt? {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
-        var transactionOptions = TransactionOptions()
-        transactionOptions.from = options.from
-        transactionOptions.to = options.to
-        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-        transactionOptions.gasLimit = .automatic
-        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
-        return self.estimateGas(transaction, transactionOptions: transactionOptions)
+        do {
+            let jsonData: Data = try JSONSerialization.data(withJSONObject: transactionJSON, options: [])
+            let transaction: EthereumTransaction = try JSONDecoder().decode(EthereumTransaction.self, from: jsonData)
+            let options: TransactionOptions = try JSONDecoder().decode(TransactionOptions.self, from: jsonData)
+            var transactionOptions = TransactionOptions()
+            transactionOptions.from = options.from
+            transactionOptions.to = options.to
+            transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+            transactionOptions.gasLimit = .automatic
+            transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+            return self.estimateGas(transaction, transactionOptions: transactionOptions)
+        } catch { return nil }
     }
     
     public func estimateGas(_ transaction: EthereumTransaction, transactionOptions: TransactionOptions) -> BigUInt? {
@@ -116,9 +122,10 @@ extension web3.BrowserFunctions {
     }
     
     public func prepareTxForApproval(_ transactionJSON: [String: Any]) -> (transaction: EthereumTransaction?, options: TransactionOptions?) {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return (nil, nil)}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return (nil, nil)}
         do {
+            let jsonData: Data = try JSONSerialization.data(withJSONObject: transactionJSON, options: [])
+            let transaction: EthereumTransaction = try JSONDecoder().decode(EthereumTransaction.self, from: jsonData)
+            let options: TransactionOptions = try JSONDecoder().decode(TransactionOptions.self, from: jsonData)
             return try self.prepareTxForApproval(transaction, options: options)
         } catch {
             return (nil, nil)
@@ -144,20 +151,23 @@ extension web3.BrowserFunctions {
     }
     
     public func signTransaction(_ transactionJSON: [String: Any], password: String = "web3swift") -> String? {
-        guard let transaction = EthereumTransaction.fromJSON(transactionJSON) else {return nil}
-        guard let options = TransactionOptions.fromJSON(transactionJSON) else {return nil}
-        var transactionOptions = TransactionOptions()
-        transactionOptions.from = options.from
-        transactionOptions.to = options.to
-        transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
-        transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
-        transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
-        if let nonceString = transactionJSON["nonce"] as? String, let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) {
-            transactionOptions.nonce = .manual(nonce)
-        } else {
-            transactionOptions.nonce = .pending
-        }
-        return self.signTransaction(transaction, transactionOptions: transactionOptions, password: password)
+        do {
+            let jsonData: Data = try JSONSerialization.data(withJSONObject: transactionJSON, options: [])
+            let transaction: EthereumTransaction = try JSONDecoder().decode(EthereumTransaction.self, from: jsonData)
+            let options: TransactionOptions = try JSONDecoder().decode(TransactionOptions.self, from: jsonData)
+            var transactionOptions = TransactionOptions()
+            transactionOptions.from = options.from
+            transactionOptions.to = options.to
+            transactionOptions.value = options.value != nil ? options.value! : BigUInt(0)
+            transactionOptions.gasLimit = options.gasLimit != nil ? options.gasLimit! : .automatic
+            transactionOptions.gasPrice = options.gasPrice != nil ? options.gasPrice! : .automatic
+            if let nonceString = transactionJSON["nonce"] as? String, let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) {
+                transactionOptions.nonce = .manual(nonce)
+            } else {
+                transactionOptions.nonce = .pending
+            }
+            return self.signTransaction(transaction, transactionOptions: transactionOptions, password: password)
+        } catch { return nil }
     }
     
     public func signTransaction(_ trans: EthereumTransaction, transactionOptions: TransactionOptions, password: String = "web3swift") -> String? {

--- a/Sources/web3swift/Transaction/EthereumTransaction.swift
+++ b/Sources/web3swift/Transaction/EthereumTransaction.swift
@@ -353,51 +353,5 @@ public extension EthereumTransaction {
         }
         return tx
     }
-    
-    static func fromJSON(_ json: [String: Any]) -> EthereumTransaction? {
-        guard let options = TransactionOptions.fromJSON(json) else {return nil}
-        guard let toString = json["to"] as? String else {return nil}
-        var to: EthereumAddress
-        if toString == "0x" || toString == "0x0" {
-            to = EthereumAddress.contractDeploymentAddress()
-        } else {
-            guard let ethAddr = EthereumAddress(toString) else {return nil}
-            to = ethAddr
-        }
-        //        if (!to.isValid) {
-        //            return nil
-        //        }
-        var dataString = json["data"] as? String
-        if (dataString == nil) {
-            dataString = json["input"] as? String
-        }
-        guard dataString != nil, let data = Data.fromHex(dataString!) else {return nil}
-        var transaction = EthereumTransaction(to: to, data: data, options: options)
-        if let nonceString = json["nonce"] as? String {
-            guard let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) else {return nil}
-            transaction.nonce = nonce
-        }
-        if let vString = json["v"] as? String {
-            guard let v = BigUInt(vString.stripHexPrefix(), radix: 16) else {return nil}
-            transaction.v = v
-        }
-        if let rString = json["r"] as? String {
-            guard let r = BigUInt(rString.stripHexPrefix(), radix: 16) else {return nil}
-            transaction.r = r
-        }
-        if let sString = json["s"] as? String {
-            guard let s = BigUInt(sString.stripHexPrefix(), radix: 16) else {return nil}
-            transaction.s = s
-        }
-        if let valueString = json["value"] as? String {
-            guard let value = BigUInt(valueString.stripHexPrefix(), radix: 16) else {return nil}
-            transaction.value = value
-        }
-        let inferedChainID = transaction.inferedChainID
-        if (transaction.inferedChainID != nil && transaction.v >= BigUInt(37)) {
-            transaction.chainID = inferedChainID
-        }
-        return transaction
-    }
-    
+
 }

--- a/Sources/web3swift/Web3/Web3+Options.swift
+++ b/Sources/web3swift/Web3/Web3+Options.swift
@@ -108,7 +108,7 @@ public struct TransactionOptions {
             return nil
         }
     }
-    
+
     public func merge(_ otherOptions: TransactionOptions?) -> TransactionOptions {
         guard let other = otherOptions else {return self}
         var opts = TransactionOptions()
@@ -121,45 +121,7 @@ public struct TransactionOptions {
         opts.callOnBlock = mergeIfNotNil(first: self.callOnBlock, second: other.callOnBlock)
         return opts
     }
-    
-    public static func fromJSON(_ json: [String: Any]) -> TransactionOptions? {
-        var options = TransactionOptions()
-        if let gas = json["gas"] as? String, let gasBiguint = BigUInt(gas.stripHexPrefix().lowercased(), radix: 16) {
-            options.gasLimit = .manual(gasBiguint)
-        } else if let gasLimit = json["gasLimit"] as? String, let gasgasLimitBiguint = BigUInt(gasLimit.stripHexPrefix().lowercased(), radix: 16) {
-            options.gasLimit = .limited(gasgasLimitBiguint)
-        } else {
-            options.gasLimit = .automatic
-        }
-        if let gasPrice = json["gasPrice"] as? String, let gasPriceBiguint = BigUInt(gasPrice.stripHexPrefix().lowercased(), radix: 16) {
-            options.gasPrice = .manual(gasPriceBiguint)
-        } else {
-            options.gasPrice = .automatic
-        }
-        if let value = json["value"] as? String, let valueBiguint = BigUInt(value.stripHexPrefix().lowercased(), radix: 16) {
-            options.value = valueBiguint
-        }
-        if let toString = json["to"] as? String {
-            guard let addressTo = EthereumAddress(toString) else {return nil}
-            options.to = addressTo
-        }
-        if let fromString = json["from"] as? String {
-            guard let addressFrom = EthereumAddress(fromString) else {return nil}
-            options.from = addressFrom
-        }
-        if let nonceString = json["nonce"] as? String, let nonce = BigUInt(nonceString.stripHexPrefix(), radix: 16) {
-            options.nonce = .manual(nonce)
-        } else {
-            options.nonce = .pending
-        }
-        if let callOnBlockString = json["callOnBlock"] as? String, let callOnBlock = BigUInt(callOnBlockString.stripHexPrefix(), radix: 16) {
-            options.callOnBlock = .exactBlockNumber(callOnBlock)
-        } else {
-            options.callOnBlock = .pending
-        }
-        return options
-    }
-    
+
     /// Merges two sets of topions by overriding the parameters from the first set by parameters from the second
     /// set if those are not nil.
     ///

--- a/Sources/web3swift/Web3/Web3+Structures.swift
+++ b/Sources/web3swift/Web3/Web3+Structures.swift
@@ -198,25 +198,6 @@ public struct TransactionDetails: Decodable {
         let transaction = try EthereumTransaction(from: decoder)
         self.transaction = transaction
     }
-    
-    public init? (_ json: [String: AnyObject]) {
-        let bh = json["blockHash"] as? String
-        if (bh != nil) {
-            guard let blockHash = Data.fromHex(bh!) else {return nil}
-            self.blockHash = blockHash
-        }
-        let bn = json["blockNumber"] as? String
-        let ti = json["transactionIndex"] as? String
-        
-        guard let transaction = EthereumTransaction.fromJSON(json) else {return nil}
-        self.transaction = transaction
-        if bn != nil {
-            blockNumber = BigUInt(bn!.stripHexPrefix(), radix: 16)
-        }
-        if ti != nil {
-            transactionIndex = BigUInt(ti!.stripHexPrefix(), radix: 16)
-        }
-    }
 }
 
 public struct TransactionReceipt: Decodable {
@@ -418,25 +399,10 @@ public enum TransactionInBlock:Decodable {
         if let string = try? value.decode(String.self) {
             guard let d = Data.fromHex(string) else {throw Web3Error.dataError}
             self = .hash(d)
-        } else if let dict = try? value.decode([String:String].self) {
-//            guard let t = try? EthereumTransaction(from: decoder) else {throw Web3Error.dataError}
-            guard let t = EthereumTransaction.fromJSON(dict) else {throw Web3Error.dataError}
-            self = .transaction(t)
+        } else if let transaction = try? value.decode(EthereumTransaction.self) {
+            self = .transaction(transaction)
         } else {
             self = .null
-        }
-    }
-    
-    
-    public init?(_ data: AnyObject) {
-        if let string = data as? String {
-            guard let d = Data.fromHex(string) else {return nil}
-            self = .hash(d)
-        } else if let dict = data as? [String:AnyObject] {
-            guard let t = EthereumTransaction.fromJSON(dict) else {return nil}
-            self = .transaction(t)
-        } else {
-            return nil
         }
     }
 }


### PR DESCRIPTION
Changed the parsing in TransactionInBlock to properly use the Decodable protocol instead of unnecessarily switching over to JSON parsing

Removed all the old (now completely dead) JSON based parsing code. No point in keeping the JSON code as it duplicates the Decodable code, and makes code maintenance more difficult