### PR TITLE
add indentation check [default is 4 spaces per tab-stop]

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,7 @@ opt_in_rules:
  - empty_string
  - closure_body_length
  - fallthrough
+ - indentation_width
 
 # force warnings
 force_cast: error


### PR DESCRIPTION
As the title says, simply enables the indentation rule to swiftlint