### PR TITLE
Feature/transaction metadata

### DIFF
--- a/Sources/web3swift/Transaction/EthereumMetadata.swift
+++ b/Sources/web3swift/Transaction/EthereumMetadata.swift
@@ -1,0 +1,57 @@
+//  Package: web3swift
+//  Created by Alex Vlasov.
+//  Copyright © 2018 Alex Vlasov. All rights reserved.
+//
+//  Additions for metadata by Mark Loit 2022
+
+import Foundation
+import BigInt
+
+/// This structure holds additional data
+/// returned by nodes when reading a transaction
+/// from the blockchain. The data here is not 
+/// part of the transaction itself
+public struct EthereumMetadata {
+
+    /// hash for the block that contains this transaction on chain
+    var blockHash: Data?
+
+    /// block number for the block containing this transaction on chain
+    var blockNumber: BigUInt?
+
+    /// index for this transaction within the containing block
+    var transactionIndex: UInt?
+
+    /// hash for this transaction as returned by the node [not computed]
+    /// this can be used for validation against the computed hash returned
+    /// by the transaction envelope.
+    var transactionHash: Data?
+
+    /// gasPrice value returned by the node
+    /// note this is a duplicate value for legacy and EIP-2930 transaction types
+    /// but is included here since EIP-1159 does not contain a `gasPrice`, but 
+    /// nodes still report the value.
+    var gasPrice: BigUInt?
+}
+
+public extension EthereumMetadata {
+    private enum CodingKeys: String, CodingKey {
+        case blockHash
+        case blockNumber
+        case transactionIndex
+        case transactionHash
+        case gasPrice
+    }
+
+    /// since metadata realistically can only come when a transaction is created from
+    /// JSON returned by a node, we only provide an intializer from JSON
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.blockHash = try container.decodeHexIfPresent(Data.self, forKey: .blockHash)
+        self.transactionHash = try container.decodeHexIfPresent(Data.self, forKey: .transactionHash)
+        self.transactionIndex = try container.decodeHexIfPresent(UInt.self, forKey: .transactionIndex)
+        self.blockNumber = try container.decodeHexIfPresent(BigUInt.self, forKey: .blockNumber)
+        self.gasPrice = try container.decodeHexIfPresent(BigUInt.self, forKey: .gasPrice)
+    }
+}

--- a/Sources/web3swift/Transaction/EthereumMetadata.swift
+++ b/Sources/web3swift/Transaction/EthereumMetadata.swift
@@ -29,7 +29,7 @@ public struct EthereumMetadata {
 
     /// gasPrice value returned by the node
     /// note this is a duplicate value for legacy and EIP-2930 transaction types
-    /// but is included here since EIP-1159 does not contain a `gasPrice`, but 
+    /// but is included here since EIP-1559 does not contain a `gasPrice`, but 
     /// nodes still report the value.
     var gasPrice: BigUInt?
 }

--- a/Sources/web3swift/Transaction/EthereumTransaction.swift
+++ b/Sources/web3swift/Transaction/EthereumTransaction.swift
@@ -336,10 +336,7 @@ extension EthereumTransaction {
                 guard let env = self.envelope as? EIP2930Envelope else { preconditionFailure("Unable to downcast to EIP2930Envelope") }
                 return env.parameters.gasPrice ?? 0
             case .eip1559:
-                // MARK: workaround for gasPrice coming from nodes for EIP-1159 - this allows Oracle to work for now
-                guard let env = self.envelope as? EIP1559Envelope else { preconditionFailure("Unable to downcast to EIP1559Envelope") }
-                return env.parameters.gasPrice ?? 0
-                // preconditionFailure("EIP1559Envelope has no member gasPrice")
+                preconditionFailure("EIP1559Envelope has no member gasPrice")
             }
         }
         set(value) {

--- a/Sources/web3swift/Transaction/EthereumTransaction.swift
+++ b/Sources/web3swift/Transaction/EthereumTransaction.swift
@@ -14,6 +14,10 @@ public struct EthereumTransaction: CustomStringConvertible {
     /// and type specific implementation
     internal var envelope: AbstractEnvelope
 
+    /// storage container for additional metadata returned by the node
+    /// when a transaction is decoded form a JSON stream
+    public var meta: EthereumMetadata?
+
     // convenience accessors to the common envelope fields
     // everything else should come from getOpts/setOpts
     /// The type of the transacton being represented, see TransactionType enum
@@ -227,6 +231,8 @@ extension EthereumTransaction: Decodable {
     public init(from decoder: Decoder) throws {
         guard let env = try EnvelopeFactory.createEnvelope(from: decoder) else { throw Web3Error.dataError }
         self.envelope = env
+        // capture any metadata that might be present
+        self.meta = try EthereumMetadata(from: decoder)
     }
 }
 

--- a/Sources/web3swift/Web3/Web3+GasOracle.swift
+++ b/Sources/web3swift/Web3/Web3+GasOracle.swift
@@ -139,7 +139,7 @@ extension Web3 {
                         return transaction
                     }
                 }
-                .map { $0.gasPrice }
+                .map { $0.meta?.gasPrice ?? 0 }
 
             return calculatePercentiles(for: lastNthBlockGasPrice)
         }

--- a/web3swift.podspec
+++ b/web3swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name         = 'web3swift'
-    spec.version      = '2.5.1'
+    spec.version      = '2.6.0'
     spec.ios.deployment_target = "9.0"
     spec.osx.deployment_target = "10.12"
     spec.license      = { :type => 'Apache License 2.0', :file => 'LICENSE.md' }

--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		6049F416280616FC00DFE624 /* LegacyEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049F40F280616FC00DFE624 /* LegacyEnvelope.swift */; };
 		6049F4182806171300DFE624 /* Web3+Signing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049F4172806171300DFE624 /* Web3+Signing.swift */; };
 		604FA4FF27ECBDC80021108F /* DataConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604FA4FE27ECBDC80021108F /* DataConversionTests.swift */; };
+		60C1786E2809BA0C0083F064 /* EthereumMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60C1786D2809BA0C0083F064 /* EthereumMetadata.swift */; };
 		CB50A52827060BD600D7E39B /* EIP712Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB50A52727060BD600D7E39B /* EIP712Tests.swift */; };
 		D606A56B279F5D59003643ED /* web3swiftDecodeSolidityErrorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D606A56A279F5D59003643ED /* web3swiftDecodeSolidityErrorType.swift */; };
 		D6A3D9B827F1E785009E3BCF /* ABIEncoderSoliditySha3Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A3D9B727F1E785009E3BCF /* ABIEncoderSoliditySha3Test.swift */; };
@@ -433,6 +434,7 @@
 		6049F40F280616FC00DFE624 /* LegacyEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyEnvelope.swift; sourceTree = "<group>"; };
 		6049F4172806171300DFE624 /* Web3+Signing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Web3+Signing.swift"; sourceTree = "<group>"; };
 		604FA4FE27ECBDC80021108F /* DataConversionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataConversionTests.swift; sourceTree = "<group>"; };
+		60C1786D2809BA0C0083F064 /* EthereumMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EthereumMetadata.swift; sourceTree = "<group>"; };
 		CB50A52727060BD600D7E39B /* EIP712Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EIP712Tests.swift; sourceTree = "<group>"; };
 		CB50A52927060C5300D7E39B /* EIP712.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EIP712.swift; sourceTree = "<group>"; };
 		D606A56A279F5D59003643ED /* web3swiftDecodeSolidityErrorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = web3swiftDecodeSolidityErrorType.swift; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 				6049F40F280616FC00DFE624 /* LegacyEnvelope.swift */,
 				3AA8153D2276E44100F5DB52 /* BloomFilter.swift */,
 				3AA8153F2276E44100F5DB52 /* EthereumTransaction.swift */,
+				60C1786D2809BA0C0083F064 /* EthereumMetadata.swift */,
 			);
 			path = Transaction;
 			sourceTree = "<group>";
@@ -1349,6 +1352,7 @@
 				3AA815C12276E44100F5DB52 /* Web3+BrowserFunctions.swift in Sources */,
 				3AA815E82276E44100F5DB52 /* Extensions.swift in Sources */,
 				3AA815FE2276E44100F5DB52 /* Web3+ERC820.swift in Sources */,
+				60C1786E2809BA0C0083F064 /* EthereumMetadata.swift in Sources */,
 				3AA815DB2276E44100F5DB52 /* Web3+TxPool.swift in Sources */,
 				3AA8160A2276E44100F5DB52 /* Web3+ERC1594.swift in Sources */,
 				3AA815FB2276E44100F5DB52 /* Promise+Web3+Personal+UnlockAccount.swift in Sources */,


### PR DESCRIPTION
This PR adds a new metadata struct that captures and stores additional data that is returned by a node when getting transaction information, but is not part of the transaction itself. This was inspired by the issue of `gasPrice` data being present for EIP-1559 transactions, even though EIP-1559 transactions have no such field, but `Oracle` was written to depend on this data for its calculations. Consequently `Oracle` has also been updated to use the new `meta` field added to `EthereumTransaction`  