### PR TITLE
Ganache Block Generator

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,11 @@ let package = Package(
                 .copy("../../../TestToken/Helpers/TokenBasics/IERC20.sol"),
                 .copy("../../../TestToken/Token/Web3SwiftToken.sol")
             ]
-        )
+        ),
+        .testTarget(
+            name: "ganacheGenerator",
+            dependencies: ["web3swift"],
+            path: "Tests/ganacheGenerator"
+        ),
     ]
 )

--- a/Tests/ganacheGenerator/GanacheGenerator.swift
+++ b/Tests/ganacheGenerator/GanacheGenerator.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+import BigInt
+
+@testable import web3swift
+
+// Dummy Test-suite
+// used to generate 25 blocks on the Ganache blockchain so that our localTests can run properly
+// this only needs to be run once on a clean Ganache environment
+// if you save the Ganache state after running this once, you never need to run it agan
+// just reset Ganache to that state instead of a new clean start
+class GanacheGenerator: XCTestCase {
+    static let url = URL.init(string: "http://127.0.0.1:8545")!
+
+    func testGenerateData() throws {
+
+        let web3 = try! Web3.new(GanacheGenerator.url)
+
+        let block = try! web3.eth.getBlockNumber()
+        if block >= 25 { return }
+
+        print("\n ****** Preloading Ganache (\(25 - block) blocks) *****\n")
+
+        let allAddresses = try! web3.eth.getAccounts()
+        let sendToAddress = allAddresses[0]
+        let contract = web3.contract(Web3.Utils.coldWalletABI, at: sendToAddress, abiVersion: 2)
+        let value = Web3.Utils.parseToBigUInt("1.0", units: .eth)
+
+        let from = allAddresses[0]
+        let writeTX = contract!.write("fallback")!
+        writeTX.transactionOptions.from = from
+        writeTX.transactionOptions.value = value
+        writeTX.transactionOptions.gasLimit = .manual(78423)
+        writeTX.transactionOptions.gasPrice = .manual(20000000000)
+
+        for _ in block..<25 {
+            let result = try! writeTX.sendPromise(password: "").wait()
+
+            let txHash = result.hash
+            print("Transaction with hash " + txHash)
+
+            Thread.sleep(forTimeInterval: 1.0)
+
+            let receipt = try web3.eth.getTransactionReceipt(txHash)
+            print(receipt)
+            XCTAssert(receipt.status == .ok)
+
+        }
+
+        print("\n***** Ganache has been initialized, you can now run the local tests *****\n")
+
+    }
+
+
+}

--- a/Tests/web3swiftTests/localTests/LocalTests.xctestplan
+++ b/Tests/web3swiftTests/localTests/LocalTests.xctestplan
@@ -15,6 +15,7 @@
     {
       "skippedTests" : [
         "ENSTests",
+        "GanacheGenerator",
         "GasOracleTests",
         "InfuraTests",
         "OracleTests",

--- a/Tests/web3swiftTests/web3swift.xctestplan
+++ b/Tests/web3swiftTests/web3swift.xctestplan
@@ -19,6 +19,9 @@
   "testTargets" : [
     {
       "parallelizable" : true,
+      "skippedTests" : [
+        "GanacheGenerator"
+      ],
       "target" : {
         "containerPath" : "container:web3swift.xcodeproj",
         "identifier" : "139751B6219AF76D0044D2B0",

--- a/ganacheGenerator.xctestplan
+++ b/ganacheGenerator.xctestplan
@@ -1,7 +1,7 @@
 {
   "configurations" : [
     {
-      "id" : "66042A4A-495F-4753-9DC9-F717EBB059FD",
+      "id" : "3A792090-A626-4D9B-8232-FFB4E29082A7",
       "name" : "Configuration 1",
       "options" : {
 
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {
@@ -17,10 +17,13 @@
         "ABIEncoderSoliditySha3Test",
         "DataConversionTests",
         "EIP1559BlockTests",
-        "EIP1559Tests",
         "EIP712Tests",
-        "GanacheGenerator",
-        "SoliditySha3Test",
+        "ENSTests",
+        "InfuraTests",
+        "OracleTests",
+        "RemoteParsingTests",
+        "ST20AndSecurityTokenTests",
+        "WebsocketTests",
         "web3swiftAdvancedABIv2Tests",
         "web3swiftBasicLocalNodeTests",
         "web3swiftDecodeSolidityErrorType",
@@ -36,21 +39,7 @@
         "web3swiftRLPTests",
         "web3swiftTests",
         "web3swiftTransactionsTests",
-        "web3swiftUserCases",
-        "web3swift_AdvancedABIv2_Tests",
-        "web3swift_EIP67_Tests",
-        "web3swift_EIP681_Tests",
-        "web3swift_ENS_Tests",
-        "web3swift_ERC20_Class_Tests",
-        "web3swift_Eventloop_Tests",
-        "web3swift_RLP_Tests",
-        "web3swift_Tests",
-        "web3swift_User_cases",
-        "web3swift_basic_local_node_Tests",
-        "web3swift_numberFormattingUtil_Tests",
-        "web3swift_personalSignature_Tests",
-        "web3swift_promises_Tests",
-        "web3swift_transactions_Tests"
+        "web3swiftUserCases"
       ],
       "target" : {
         "containerPath" : "container:web3swift.xcodeproj",

--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 		5CF7E8B0276B792A0009900F /* web3swiftEventloopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF7E89F276B79280009900F /* web3swiftEventloopTests.swift */; };
 		5CF7E8B1276B792A0009900F /* web3swiftAdvancedABIv2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF7E8A0276B79290009900F /* web3swiftAdvancedABIv2Tests.swift */; };
 		5CF7E8B2276B792A0009900F /* web3swiftEIP67Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF7E8A1276B79290009900F /* web3swiftEIP67Tests.swift */; };
+		6029BE7628185E33006FA0DF /* GanacheGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6029BE7528185E33006FA0DF /* GanacheGenerator.swift */; };
 		6049F410280616FC00DFE624 /* AbstractEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049F409280616FC00DFE624 /* AbstractEnvelope.swift */; };
 		6049F411280616FC00DFE624 /* EIP1559Envelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049F40A280616FC00DFE624 /* EIP1559Envelope.swift */; };
 		6049F412280616FC00DFE624 /* EIP2718Envelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6049F40B280616FC00DFE624 /* EIP2718Envelope.swift */; };
@@ -305,7 +306,6 @@
 		3AA815372276E44100F5DB52 /* EthereumKeystoreV3.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EthereumKeystoreV3.swift; sourceTree = "<group>"; };
 		3AA815392276E44100F5DB52 /* PlainKeystore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlainKeystore.swift; sourceTree = "<group>"; };
 		3AA8153A2276E44100F5DB52 /* AbstractKeystore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractKeystore.swift; sourceTree = "<group>"; };
-		3AA8153B2276E44100F5DB52 /* KeystoreV3JSONStructure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeystoreV3JSONStructure.swift; sourceTree = "<group>"; };
 		3AA8153D2276E44100F5DB52 /* BloomFilter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BloomFilter.swift; sourceTree = "<group>"; };
 		3AA8153F2276E44100F5DB52 /* EthereumTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EthereumTransaction.swift; sourceTree = "<group>"; };
 		3AA815412276E44100F5DB52 /* Web3+Wallet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Web3+Wallet.swift"; sourceTree = "<group>"; };
@@ -425,6 +425,8 @@
 		5CF7E89F276B79280009900F /* web3swiftEventloopTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = web3swiftEventloopTests.swift; sourceTree = "<group>"; };
 		5CF7E8A0276B79290009900F /* web3swiftAdvancedABIv2Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = web3swiftAdvancedABIv2Tests.swift; sourceTree = "<group>"; };
 		5CF7E8A1276B79290009900F /* web3swiftEIP67Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = web3swiftEIP67Tests.swift; sourceTree = "<group>"; };
+		6029BE7528185E33006FA0DF /* GanacheGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GanacheGenerator.swift; sourceTree = "<group>"; };
+		6029BE7728185FC4006FA0DF /* ganacheGenerator.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = file; path = ganacheGenerator.xctestplan; sourceTree = SOURCE_ROOT; };
 		6049F409280616FC00DFE624 /* AbstractEnvelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AbstractEnvelope.swift; sourceTree = "<group>"; };
 		6049F40A280616FC00DFE624 /* EIP1559Envelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EIP1559Envelope.swift; sourceTree = "<group>"; };
 		6049F40B280616FC00DFE624 /* EIP2718Envelope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EIP2718Envelope.swift; sourceTree = "<group>"; };
@@ -538,6 +540,7 @@
 		1317BDD2218C526C00D6D095 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				6029BE7328185D5B006FA0DF /* ganacheGenerator */,
 				1317404621BE96D300208B8F /* web3swiftTests */,
 			);
 			path = Tests;
@@ -705,7 +708,6 @@
 				3AA815372276E44100F5DB52 /* EthereumKeystoreV3.swift */,
 				3AA815392276E44100F5DB52 /* PlainKeystore.swift */,
 				3AA8153A2276E44100F5DB52 /* AbstractKeystore.swift */,
-				3AA8153B2276E44100F5DB52 /* KeystoreV3JSONStructure.swift */,
 			);
 			path = KeystoreManager;
 			sourceTree = "<group>";
@@ -1005,6 +1007,15 @@
 				13CE02B021FC846800CE7148 /* RELEASE_GUIDE.md */,
 			);
 			path = Documentation;
+			sourceTree = "<group>";
+		};
+		6029BE7328185D5B006FA0DF /* ganacheGenerator */ = {
+			isa = PBXGroup;
+			children = (
+				6029BE7728185FC4006FA0DF /* ganacheGenerator.xctestplan */,
+				6029BE7528185E33006FA0DF /* GanacheGenerator.swift */,
+			);
+			path = ganacheGenerator;
 			sourceTree = "<group>";
 		};
 		E252E68026B40C1600717C16 /* remoteTests */ = {
@@ -1455,6 +1466,7 @@
 				5CF7E8A6276B792A0009900F /* web3swiftHelpers.swift in Sources */,
 				5CF7E8AA276B792A0009900F /* web3swiftNumberFormattingUtilTests.swift in Sources */,
 				5CF7E8AC276B792A0009900F /* web3swiftObjCTests.swift in Sources */,
+				6029BE7628185E33006FA0DF /* GanacheGenerator.swift in Sources */,
 				5CF7E8A3276B792A0009900F /* web3swiftPersonalSignatureTests.swift in Sources */,
 				D6A3D9B827F1E785009E3BCF /* ABIEncoderSoliditySha3Test.swift in Sources */,
 			);

--- a/web3swift.xcodeproj/xcshareddata/xcschemes/web3swift.xcscheme
+++ b/web3swift.xcodeproj/xcshareddata/xcschemes/web3swift.xcscheme
@@ -47,6 +47,9 @@
          <TestPlanReference
             reference = "container:Tests/web3swiftTests/remoteTests/RemoteTests.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:ganacheGenerator.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference


### PR DESCRIPTION
This PR adds a test-suite that can be used to generate blocks in Ganache. When run it guarantees that Ganache has at least 25 blocks of history, this is required so that the local tests that depend on `Oracle` can pass. The generator only needs to be run once anytime Ganache is reset to 0. You can save the state of Ganache after running the generator, and reset to that state instead, removing the need to run the generator again.