### PR TITLE
Restore public API `fromJSON()` functions

### DIFF
--- a/Sources/web3swift/Transaction/EthereumTransaction.swift
+++ b/Sources/web3swift/Transaction/EthereumTransaction.swift
@@ -445,4 +445,14 @@ extension EthereumTransaction {
         return self.envelope.encode(for: .transaction)
     }
 
+    @available(*, deprecated, message: "use Decodable instead")
+    public static func fromJSON(_ json: [String: Any]) -> EthereumTransaction? {
+        do {
+            let jsonData: Data = try JSONSerialization.data(withJSONObject: json, options: [])
+            return try JSONDecoder().decode(EthereumTransaction.self, from: jsonData)
+        } catch {
+            return nil
+        }
+    }
+
 }

--- a/Sources/web3swift/Web3/Web3+Options.swift
+++ b/Sources/web3swift/Web3/Web3+Options.swift
@@ -280,3 +280,16 @@ extension TransactionOptions: Decodable {
         }
     }
 }
+
+extension TransactionOptions {
+    @available(*, deprecated, message: "use Decodable instead")
+    public static func fromJSON(_ json: [String: Any]) -> TransactionOptions? {
+        do {
+            let jsonData: Data = try JSONSerialization.data(withJSONObject: json, options: [])
+            return try JSONDecoder().decode(TransactionOptions.self, from: jsonData)
+        } catch {
+            return nil
+        }
+    }
+
+}


### PR DESCRIPTION
Restored the `fromJSON` functions that were removed back in `2.5.1` by one of my PR's as they were no longer referenced internally. 

As they are part of the public API they should have been refactored and marked as `deprecated`, instead of removed. I've corrected that here.