### PR TITLE
- Pointer of next element in dynamic array decoding fixed

### DIFF
--- a/Sources/web3swift/EthereumABI/ABIDecoding.swift
+++ b/Sources/web3swift/EthereumABI/ABIDecoding.swift
@@ -135,12 +135,7 @@ extension ABIDecoder {
                         let (v, c) = decodeSingleType(type: subType, data: dataSlice, pointer: subpointer)
                         guard let valueUnwrapped = v, let consumedUnwrapped = c else {break}
                         toReturn.append(valueUnwrapped)
-                        if (subType.isStatic) {
-                            subpointer = subpointer + consumedUnwrapped
-                        }
-                        else {
-                            subpointer = consumedUnwrapped // need to go by nextElementPointer
-                        }
+                        subpointer = subpointer + consumedUnwrapped
                     }
                     return (toReturn as AnyObject, nextElementPointer)
                 }


### PR DESCRIPTION
Dublicate check to subType.isStatic removed in decoding array with dynamic size and dynamic subtype value
Increment pointer of next element in array added, without this incrementing in array decoded only first element with thero address, second element with type.memoryUsage address and all next elements is decoded at type.memoryUsage - address and equal second element

issue - https://github.com/skywinder/web3swift/issues/565