### PR TITLE
correct the decoding key for `from` in `transactionOptions`

### DIFF
--- a/Sources/web3swift/Web3/Web3+Options.swift
+++ b/Sources/web3swift/Web3/Web3+Options.swift
@@ -235,7 +235,7 @@ extension TransactionOptions: Decodable {
             self.to = ethAddr
         }
 
-        self.from = try container.decodeIfPresent(EthereumAddress.self, forKey: .to)
+        self.from = try container.decodeIfPresent(EthereumAddress.self, forKey: .from)
 
         if let gasPrice = try? container.decodeHex(BigUInt.self, forKey: .gasPrice) {
             self.gasPrice = .manual(gasPrice)


### PR DESCRIPTION
This is a PR to fix the bug spotted in #569 where `TransactionOptions` was incorrectly using the `to` key instead of `from` when decoding for `from` 