### PR TITLE
Updated Starscream to custom fork: fixes issue with remote peer closing connection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,13 @@ on:
 
 jobs:
   spm:
-    name: Swift Package Manager 5.4
-    runs-on: macOS-11
+    name: Swift Package Manager 5.5
+    runs-on: macOS-12
     concurrency: 
       group: spm-${{ github.run_id }}
       cancel-in-progress: false
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: Resolve dependencies
@@ -46,7 +46,7 @@ jobs:
         run: swift test --skip-build -c debug --filter remoteTests
   carthage:
     name: Carthage
-    runs-on: macOS-11
+    runs-on: macOS-12
     concurrency: 
       group: carthage-${{ github.run_id }}
       cancel-in-progress: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       group: carthage-${{ github.run_id }}
       cancel-in-progress: false
     env:
-      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     strategy:
       fail-fast: false
       max-parallel: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        destination: ['OS=14.5,name=iPhone 12']
+        destination: ['OS=15.4,name=iPhone 12']
     steps:
       - uses: actions/checkout@v2
       - name: Resolving dependencies

--- a/Cartfile
+++ b/Cartfile
@@ -1,5 +1,5 @@
 github "attaswift/BigInt" ~> 5.3.0
 github "attaswift/SipHash" ~> 1.2.2
-github "daltoniam/Starscream" ~> 4.0.4
+github "JeneaVranceanu/Starscream" "master"
 github "krzyzanowskim/CryptoSwift" ~> 1.5.1
 github "mxcl/PromiseKit" ~> 6.16.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
+github "JeneaVranceanu/Starscream" "ed96ef4949c9d3e793c5b1adf8d287191e99a97e"
 github "attaswift/BigInt" "v5.3.0"
 github "attaswift/SipHash" "v1.2.2"
-github "daltoniam/Starscream" "4.0.4"
-github "krzyzanowskim/CryptoSwift" "1.4.2"
-github "mxcl/PromiseKit" "6.16.2"
+github "krzyzanowskim/CryptoSwift" "1.5.1"
+github "mxcl/PromiseKit" "6.17.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,17 +24,17 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
-          "revision": "7b07b214dacecb22ca4b680531c7e981d52483f9",
-          "version": "6.16.3"
+          "revision": "c946b7561fbe11379a874e59faa2c5f8077ae0e1",
+          "version": "6.17.1"
         }
       },
       {
         "package": "Starscream",
-        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
+        "repositoryURL": "https://github.com/JeneaVranceanu/Starscream.git",
         "state": {
-          "branch": null,
-          "revision": "df8d82047f6654d8e4b655d1b1525c64e1059d21",
-          "version": "4.0.4"
+          "branch": "master",
+          "revision": "ed96ef4949c9d3e793c5b1adf8d287191e99a97e",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.4
+// swift-tools-version: 5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -23,7 +23,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
         .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.16.2"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.4"),
+        .package(url: "https://github.com/JeneaVranceanu/Starscream.git", branch: "master"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.5.1")
     ],
     targets: [

--- a/Package@5.0.swift
+++ b/Package@5.0.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
         .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.15.4"),
-        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.4"),
+        .package(url: "https://github.com/JeneaVranceanu/Starscream.git", branch: "master"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.4.2")
     ],
     targets: [

--- a/Sources/web3swift/Web3/Web3+InfuraProviders.swift
+++ b/Sources/web3swift/Web3/Web3+InfuraProviders.swift
@@ -246,7 +246,7 @@ public final class InfuraWebsocketProvider: WebsocketProvider {
     }
 
     /// override WebsocketDelegate
-    override public func didReceive(event: WebSocketEvent, client: WebSocket) {
+    override public func didReceive(event: WebSocketEvent, client: WebSocketClient) {
         switch event {
         case .connected(let headers):
             debugMode ? print("websocket is connected, headers:\n \(headers)") : nil
@@ -283,6 +283,9 @@ public final class InfuraWebsocketProvider: WebsocketProvider {
             debugMode ? print("error: \(String(describing: error))") : nil
             websocketConnected = false
             delegate.gotError(error: error!)
+        case .peerClosed:
+            debugMode ? print("peerClosed") : nil
+            delegate.gotError(error: Web3Error.connectionError)
         }
     }
 

--- a/Sources/web3swift/Web3/Web3+WebsocketProvider.swift
+++ b/Sources/web3swift/Web3/Web3+WebsocketProvider.swift
@@ -283,7 +283,7 @@ public class WebsocketProvider: Web3Provider, IWebsocketProvider, WebSocketDeleg
         }
     }
 
-    public func didReceive(event: WebSocketEvent, client: WebSocket) {
+    public func didReceive(event: WebSocketEvent, client: WebSocketClient) {
         switch event {
         case .connected(let headers):
             websocketConnected = true
@@ -311,6 +311,8 @@ public class WebsocketProvider: Web3Provider, IWebsocketProvider, WebSocketDeleg
         case .error(let error):
             websocketConnected = false
             delegate.gotError(error: error!)
+        case .peerClosed:
+            delegate.gotError(error: Web3Error.connectionError)
         }
     }
 }


### PR DESCRIPTION
_Note: it includes CI updates to use macOS 12._

[Here is the link](https://github.com/daltoniam/Starscream/pull/946) to PR in Starscream library. 
[Here is also the link to the issue](https://github.com/daltoniam/Starscream/issues/935) with all details and my findings.

I doubt that it will be merged anytime soon as there is no activity on the side of maintainers but the bug this PR fixes caused quite some problems some time ago.

I know there some work is happening on the network layer but I still think it will be a good bug fix as the issue we are having with the current version of Starscream is quite significant. The issue is that once the WebSocket connection is closed by the other end (by the server in our case), we will never know that it happened, so there is no way to reconnect back to the server.

I had this issue with the project I'm working on because backend developers are using a load balancer which drops WebSocket connections every 30 seconds.