### PR TITLE
Chore: public structs with initializers

### DIFF
--- a/Sources/web3swift/Contract/ContractProtocol.swift
+++ b/Sources/web3swift/Contract/ContractProtocol.swift
@@ -58,9 +58,8 @@ public struct EventFilter {
         }
     }
 
-    public init() { }
-
-    public init(fromBlock: Block?, toBlock: Block?,
+    public init(fromBlock: Block? = nil,
+                toBlock: Block? = nil,
                 addresses: [EthereumAddress]? = nil,
                 parameterFilters: [[EventFilterable]?]? = nil) {
         self.fromBlock = fromBlock

--- a/Sources/web3swift/KeystoreManager/IBAN.swift
+++ b/Sources/web3swift/KeystoreManager/IBAN.swift
@@ -11,6 +11,12 @@ public struct ICAP {
     public var asset: String
     public var institution: String
     public var client: String
+
+    public init(asset: String, institution: String, client: String) {
+        self.asset = asset
+        self.institution = institution
+        self.client = client
+    }
 }
 
 public struct IBAN {

--- a/Sources/web3swift/Tokens/ERC1376/Web3+ERC1376.swift
+++ b/Sources/web3swift/Tokens/ERC1376/Web3+ERC1376.swift
@@ -18,14 +18,14 @@ public enum IERC1376DelegateMode: UInt {
 }
 
 public struct DirectDebitInfo {
-    let amount: BigUInt
-    let startTime: BigUInt
-    let interval: BigUInt
+    public let amount: BigUInt
+    public let startTime: BigUInt
+    public let interval: BigUInt
 }
 
 public struct DirectDebit {
-    let info: DirectDebitInfo
-    let epoch: BigUInt
+    public let info: DirectDebitInfo
+    public let epoch: BigUInt
 }
 
 extension DirectDebit: Hashable {

--- a/Sources/web3swift/Transaction/EthereumParameters.swift
+++ b/Sources/web3swift/Transaction/EthereumParameters.swift
@@ -49,6 +49,30 @@ public struct EthereumParameters {
 
     /// access list for contract execution (EIP-2930 and EIP-1559 only)
     public var accessList: [AccessListEntry]?
+
+    public init(type: TransactionType? = nil,
+                to: EthereumAddress? = nil,
+                nonce: BigUInt? = nil,
+                chainID: BigUInt? = nil,
+                value: BigUInt? = nil,
+                data: Data? = nil,
+                gasLimit: BigUInt? = nil,
+                gasPrice: BigUInt? = nil,
+                maxFeePerGas: BigUInt? = nil,
+                maxPriorityFeePerGas: BigUInt? = nil,
+                accessList: [AccessListEntry]? = nil) {
+        self.type = type
+        self.to = to
+        self.nonce = nonce
+        self.chainID = chainID
+        self.value = value
+        self.data = data
+        self.gasLimit = gasLimit
+        self.gasPrice = gasPrice
+        self.maxFeePerGas = maxFeePerGas
+        self.maxPriorityFeePerGas = maxPriorityFeePerGas
+        self.accessList = accessList
+    }
 }
 
 public extension EthereumParameters {

--- a/Sources/web3swift/Web3/Web3+Options.swift
+++ b/Sources/web3swift/Web3/Web3+Options.swift
@@ -88,6 +88,32 @@ public struct TransactionOptions {
 
     public var accessList: [AccessListEntry]?
 
+    public init(type: TransactionType? = nil,
+                to: EthereumAddress? = nil,
+                from: EthereumAddress? = nil,
+                chainID: BigUInt? = nil,
+                gasLimit: TransactionOptions.GasLimitPolicy? = nil,
+                gasPrice: TransactionOptions.GasPricePolicy? = nil,
+                maxFeePerGas: TransactionOptions.FeePerGasPolicy? = nil,
+                maxPriorityFeePerGas: TransactionOptions.FeePerGasPolicy? = nil,
+                value: BigUInt? = nil,
+                nonce: TransactionOptions.NoncePolicy? = nil,
+                callOnBlock: TransactionOptions.CallingBlockPolicy? = nil,
+                accessList: [AccessListEntry]? = nil) {
+        self.type = type
+        self.to = to
+        self.from = from
+        self.chainID = chainID
+        self.gasLimit = gasLimit
+        self.gasPrice = gasPrice
+        self.maxFeePerGas = maxFeePerGas
+        self.maxPriorityFeePerGas = maxPriorityFeePerGas
+        self.value = value
+        self.nonce = nonce
+        self.callOnBlock = callOnBlock
+        self.accessList = accessList
+    }
+
     public static var defaultOptions: TransactionOptions {
         var opts = TransactionOptions()
         opts.type = .legacy


### PR DESCRIPTION
Added initializers to **public** structs that had none.
By default, structs have initializers that are usable within the project because these initializers have an `internal` access modifier. 
That initializer is obviously inaccessible when some library is used as a dependency in a different project.

Example of initializers available in 3rd party project for `EthereumParameters` (default internal initializer is not visible): 

<img width="660" alt="Screenshot 2022-07-19 at 10 48 12" src="https://user-images.githubusercontent.com/36865532/179704348-ac5d6e0a-0681-4203-a644-79ab63869f3d.png">

<img width="653" alt="Screenshot 2022-07-19 at 10 48 19" src="https://user-images.githubusercontent.com/36865532/179704340-d432861f-ef89-475c-bbd1-f906a39b60cf.png">

