### PR TITLE
Decode single JSONRPCresponse

### DIFF
--- a/Sources/web3swift/Web3/Web3+JSONRPC.swift
+++ b/Sources/web3swift/Web3/Web3+JSONRPC.swift
@@ -236,9 +236,14 @@ public struct JSONRPCresponseBatch: Decodable {
     var responses: [JSONRPCresponse]
 
     public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let responses = try container.decode([JSONRPCresponse].self)
-        self.responses = responses
+		let container = try decoder.singleValueContainer()
+		guard let responses = try? container.decode([JSONRPCresponse].self) else {
+			let response = try container.decode(JSONRPCresponse.self)
+			self.responses = [response]
+			return
+		}
+		
+		self.responses = responses
     }
 }
 


### PR DESCRIPTION
When receiving a single JSONRPCrespone object, the decoder expects to decode an Array which throws an error. 

Fixes #254