### PR TITLE
Update podspecs

### DIFF
--- a/Web3Core.podspec
+++ b/Web3Core.podspec
@@ -1,20 +1,18 @@
 Pod::Spec.new do |spec|
-    spec.name         = 'web3swift'
+    spec.name         = 'Web3Core'
     spec.version      = '3.0.0-RC3'
+    spec.module_name  = 'Core'
     spec.ios.deployment_target = "13.0"
     spec.osx.deployment_target = "10.15"
     spec.license      = { :type => 'Apache License 2.0', :file => 'LICENSE.md' }
-    spec.summary      = 'Web3 implementation in vanilla Swift for iOS, macOS, and Linux'
+    spec.summary      = 'Core of web3swift library'
     spec.homepage     = 'https://github.com/matter-labs/web3swift'
     spec.author       = {"Alex Vlasov" => "alex.m.vlasov@gmail.com", "Anton Grigorev" => "antongrigorjev2010@gmail.com", "Petr Korolev" => "sky4winder@gmail.com", "Yaroslav Yashin" => "yaroslav.yashin@gmail.com"}
     spec.source       = { :git => 'https://github.com/matter-labs/web3swift.git', :tag => spec.version.to_s }
     spec.swift_version = '5.5'
 
-    # Make this line same as Web3Core sources
-    spec.source_files =  "Sources/web3swift/{Contract,Convenience,EthereumABI,HookedFunctions,EthereumAPICalls,Web3}/*.swift", "Sources/web3swift/{EthereumAPICalls,Tokens,Utils}/**/*.swift"
-    spec.ios.source_files   = 'Sources/web3swift/Browser/*.swift'
-    spec.resource_bundle = { "Browser" => "Sources/web3swift/Browser/*.js" }
-    spec.frameworks = 'CoreImage'
-    spec.dependency 'Starscream', '~> 4.0.4'
-    spec.dependency 'Web3Core', '~> 3.0.0-RC3'
+    spec.dependency 'secp256k1.c', '~> 0.1'
+    spec.dependency 'BigInt', '~> 5.2.0'
+    spec.dependency 'CryptoSwift', '~> 1.5.1'
+    spec.source_files = "Sources/Core/**/*.swift"
 end


### PR DESCRIPTION
- Add separate `Web3Core.podspec` because there's no way to manage modules SPM way within Cocoapods
- Update deployment target to 13.0 and 10.15 for iOS and macOS respectively (async/await requirement)
- Update minimum swift version to 5.5 (async/await requirement)