### PR TITLE
Fix for EIP681: parsing of arrays and encoding of EIP681Code into URL

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -60,7 +60,7 @@ extension Web3 {
 <<<<<<< HEAD
 =======
 
-        public func makeEIP681Link() -> String? {
+        public func makeEIP681Link(urlEncode: Bool = false) -> String? {
             let address: String
             switch targetAddress {
             case .ethereumAddress(let ethereumAddress):
@@ -87,7 +87,7 @@ extension Web3 {
                     link = "\(link)?\(queryParameters.joined(separator: "&"))"
                 }
             }
-            return link
+            return urlEncode ? link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) : link
         }
     }
 

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -57,8 +57,6 @@ extension Web3 {
             self.isPayRequest = isPayRequest
             self.targetAddress = targetAddress
         }
-<<<<<<< HEAD
-=======
 
         public func makeEIP681Link(urlEncode: Bool = false) -> String? {
             let address: String
@@ -230,7 +228,6 @@ extension Web3 {
             default: return nil
             }
         }
->>>>>>> 35c85fd7... feat: encoding query parameters for EIP681 - except tuples, this is still a TODO
     }
 
     public struct EIP681CodeParser {

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -107,7 +107,7 @@ extension Web3 {
                     if let ethAddress = EthereumAddress(string) {
                         return ethAddress.address
                     }
-                    if let url = URL(string: string) {
+                    if URL(string: string) != nil {
                         return string
                     }
                 }
@@ -163,7 +163,7 @@ extension Web3 {
                     return Data(bytes).toHexString().addHexPrefix()
                 } else if let string = rawValue as? String {
                     if let bytes = Data.fromHex(string) {
-                        return string.addHexPrefix()
+                        return bytes.toHexString().addHexPrefix()
                     }
                     return string.data(using: .utf8)?.toHexString().addHexPrefix()
                 }
@@ -177,8 +177,9 @@ extension Web3 {
                 } else if let string = rawValue as? String {
                     if let bytes = Data.fromHex(string) {
                         data = bytes
+                    } else {
+                        data = string.data(using: .utf8)
                     }
-                    data = string.data(using: .utf8)
                 }
 
                 if let data = data,

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -28,7 +28,7 @@ extension Web3 {
 <<<<<<< HEAD
 =======
 
-            public init(type: ABI.Element.ParameterType, value: Any) {
+            public init(type: ABI.Element.ParameterType, value: AnyObject) {
                 self.type = type
                 self.value = value
             }

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -25,6 +25,14 @@ extension Web3 {
         public struct EIP681Parameter {
             public var type: ABI.Element.ParameterType
             public var value: AnyObject
+<<<<<<< HEAD
+=======
+
+            public init(type: ABI.Element.ParameterType, value: Any) {
+                self.type = type
+                self.value = value
+            }
+>>>>>>> c159f067... Make value as any object in eip681 parameters
         }
         public var isPayRequest: Bool
         public var targetAddress: TargetAddress

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -461,7 +461,9 @@ extension Web3 {
             /// Dropping first and last square brackets.
             /// That modifies the upper bound value of the first match of `squareBracketRegex`.
             let rawValue = String(rawValue.dropFirst().dropLast())
-
+            
+            // TODO: try replacing this manual parsing with JSONDecoder and RawRepresentable
+            
             let squareBracketRegex = try! NSRegularExpression(pattern: "(\\[*)")
             let match = squareBracketRegex.firstMatch(in: rawValue, range: rawValue.fullNSRange)
 
@@ -504,7 +506,9 @@ extension Web3 {
         private static func splitArrayOfStrings(_ rawValue: String) -> [String]? {
             /// Dropping first and last square brackets to exclude them from the first and the last separated element.
             let rawValue = String(rawValue.dropFirst().dropLast())
-
+            
+            // TODO: try replacing this manual parsing with JSONDecoder and RawRepresentable
+            
             let elementsBoundary = try! NSRegularExpression(pattern: "\",\"")
             var indices = Array(elementsBoundary
                 .matches(in: rawValue, range: rawValue.fullNSRange)

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -303,6 +303,12 @@ class EIP681Tests: LocalTestCase {
                                  Web3.EIP681Code.EIP681Parameter(type: .string,
                                                                  value: "this is EIP681 query parameter string" as AnyObject)]
 
-        XCTAssertEqual(eip681Link.makeEIP681Link(), "ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc/setData?bytes32[]=[0x1234789565875498655487123478956587549865548712347895658754980000,0x1234789565875498655487123478956587549865548712347895658754986554]&bytes[]=[0x12345607,0x8965abcdef]&uint256=98986565&int256=155445566&address=0x9aBbDB06A61cC686BD635484439549D45c2449cc&bytes5=0x9abbdb06a6&bytes3=0x9abbdb&bytes=0x11009abbdb87879898656545&string=this is EIP681 query parameter string")
+        let unencodedResult =  "ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc/setData?bytes32[]=[0x1234789565875498655487123478956587549865548712347895658754980000,0x1234789565875498655487123478956587549865548712347895658754986554]&bytes[]=[0x12345607,0x8965abcdef]&uint256=98986565&int256=155445566&address=0x9aBbDB06A61cC686BD635484439549D45c2449cc&bytes5=0x9abbdb06a6&bytes3=0x9abbdb&bytes=0x11009abbdb87879898656545&string=this is EIP681 query parameter string"
+
+        XCTAssertEqual(eip681Link.makeEIP681Link(), unencodedResult)
+        let encodedOutputLink = eip681Link.makeEIP681Link(urlEncode: true)
+        XCTAssertEqual(encodedOutputLink, unencodedResult.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssertNotNil(encodedOutputLink)
+        XCTAssertNotNil(URL(string: encodedOutputLink ?? ""))
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -6,14 +6,15 @@
 
 import XCTest
 import BigInt
+import Core
 
 @testable import web3swift
 
-class EIP681Tests: LocalTestCase {
+class EIP681Tests: XCTestCase {
 
-    func testParsing() throws {
+    func testParsing() async throws {
         let testAddress = "0x5ffc014343cd971b7eb70732021e26c35b744cc4"
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18")
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18")
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -26,9 +27,9 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(eip681Code.amount, BigUInt(2014000000000000000))
     }
 
-    func testParsingWithEncoding() throws {
+    func testParsingWithEncoding() async throws {
         let testAddress = "0x5ffc014343cd971b7eb70732021e26c35b744cc4"
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -40,9 +41,9 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(eip681Code.amount, BigUInt(2014000000000000000))
     }
 
-    func testParsing2() throws {
+    func testParsing2() async throws {
         let testAddress = "0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1"
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1")
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1")
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -60,9 +61,9 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
     }
 
-    func testParsing2WithEncoding() throws {
+    func testParsing2WithEncoding() async throws {
         let testAddress = "0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1"
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1"
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1"
             .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
@@ -81,9 +82,9 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
     }
 
-    func testENSParsing() throws {
+    func testENSParsing() async throws {
         let testAddress = "somename.eth"
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1")
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1")
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -103,9 +104,9 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
     }
 
-    func testENSParsingWithEncoding() throws {
+    func testENSParsingWithEncoding() async throws {
         let testAddress = "somename.eth"
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -125,10 +126,10 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
     }
 
-    func testParsingOfArrayOfBytesAsParameter() throws {
+    func testParsingOfArrayOfBytesAsParameter() async throws {
         let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
         let chainID = BigUInt(2828)
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]")
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]")
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -155,10 +156,10 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data?[2], Data.fromHex("0x005e9F5BB83481d5627aA8c48527C174579bC428")!)
     }
 
-    func testParsingOfArrayOfBytesAsParameterWithEncoding() throws {
+    func testParsingOfArrayOfBytesAsParameterWithEncoding() async throws {
         let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
         let chainID = BigUInt(2828)
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -185,10 +186,10 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data?[2], Data.fromHex("0x005e9F5BB83481d5627aA8c48527C174579bC428")!)
     }
 
-    func testParsingOfArrayOfIntAsParameter() throws {
+    func testParsingOfArrayOfIntAsParameter() async throws {
         let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
         let chainID = BigUInt(2828)
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[]=[1,2,5000,3,4,10000]")
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[]=[1,2,5000,3,4,10000]")
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -207,10 +208,10 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data, Array<BigInt>(arrayLiteral: 1, 2, 5000, 3, 4, 10000))
     }
 
-    func testParsingOfArrayOfIntOfFixedLengthAsParameter() throws {
+    func testParsingOfArrayOfIntOfFixedLengthAsParameter() async throws {
         let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
         let chainID = BigUInt(2828)
-        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[3]=[1,2,5000]")
+        let eip681Code = await Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[3]=[1,2,5000]")
         XCTAssert(eip681Code != nil)
         guard let eip681Code = eip681Code else { return }
         switch eip681Code.targetAddress {
@@ -229,19 +230,19 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data, Array<BigInt>(arrayLiteral: 1, 2, 5000))
     }
 
-    func testParsingQueryParameterFixedLengthArray() throws {
+    func testParsingQueryParameterFixedLengthArray() async throws {
         /// Declared `int256[3]` with 2 values instead of expected 3.
-        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2]")
+        var eip681Code = await Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2]")
         XCTAssert(eip681Code != nil)
         XCTAssert(eip681Code?.parameters.count == 0)
         /// Declared `int256[3]` with 4 values instead of expected 3.
-        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2,2,3]")
+        eip681Code = await Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2,2,3]")
         XCTAssert(eip681Code != nil)
         XCTAssert(eip681Code?.parameters.count == 0)
     }
 
-    func testParsingQueryParameterStringsArray() throws {
-        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[\"123\",\"2,5000\",\"wwweer2-=!\"]")
+    func testParsingQueryParameterStringsArray() async throws {
+        var eip681Code = await Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[\"123\",\"2,5000\",\"wwweer2-=!\"]")
         XCTAssert(eip681Code != nil)
         guard eip681Code != nil else { return }
 
@@ -249,7 +250,7 @@ class EIP681Tests: LocalTestCase {
         var data = eip681Code!.parameters[0].value as? [String]
         XCTAssertEqual(data, ["123","2,5000","wwweer2-=!"])
 
-        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[123,2,5000,wwweer2-=!]")
+        eip681Code = await Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[123,2,5000,wwweer2-=!]")
         XCTAssert(eip681Code != nil)
         guard eip681Code != nil else { return }
 
@@ -258,8 +259,8 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data, ["123","2","5000","wwweer2-=!"])
     }
 
-    func testParsingQueryParameterArrayOfStringsArrays() throws {
-        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[\"123\",\"2,5000\",\"wwweer2-=!\"],[\"test1\",\"demo\"]]")
+    func testParsingQueryParameterArrayOfStringsArrays() async throws {
+        var eip681Code = await Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[\"123\",\"2,5000\",\"wwweer2-=!\"],[\"test1\",\"demo\"]]")
         XCTAssert(eip681Code != nil)
         guard eip681Code != nil else { return }
 
@@ -268,7 +269,7 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data?[0], ["123","2,5000","wwweer2-=!"])
         XCTAssertEqual(data?[1], ["test1","demo"])
 
-        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[123,2,5000,wwweer2-=!],[test1,demo]]")
+        eip681Code = await Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[123,2,5000,wwweer2-=!],[test1,demo]]")
         XCTAssert(eip681Code != nil)
         guard eip681Code != nil else { return }
 
@@ -278,7 +279,7 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data?[1], ["test1","demo"])
     }
 
-    func testMakeEIP681Link() throws {
+    func testMakeEIP681Link() async throws {
         var eip681Link = Web3.EIP681Code(Web3.EIP681Code.TargetAddress.ethereumAddress(EthereumAddress("0x9aBbDB06A61cC686BD635484439549D45c2449cc")!))
 
         eip681Link.functionName = "setData"

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -277,4 +277,32 @@ class EIP681Tests: LocalTestCase {
         XCTAssertEqual(data?[0], ["123","2","5000","wwweer2-=!"])
         XCTAssertEqual(data?[1], ["test1","demo"])
     }
+
+    func testMakeEIP681Link() throws {
+        var eip681Link = Web3.EIP681Code(Web3.EIP681Code.TargetAddress.ethereumAddress(EthereumAddress("0x9aBbDB06A61cC686BD635484439549D45c2449cc")!))
+
+        eip681Link.functionName = "setData"
+        eip681Link.parameters = [Web3.EIP681Code.EIP681Parameter(type: .array(type: .bytes(length: 32), length: 0),
+                                                                 value: [Data.fromHex("0x1234789565875498655487123478956587549865548712347895658754980000")!,
+                                                                         Data.fromHex("0x1234789565875498655487123478956587549865548712347895658754986554")!] as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .array(type: .dynamicBytes, length: 0),
+                                                                 value: [Data.fromHex("0x12345607")!,
+                                                                         Data.fromHex("0x8965abcdef")!] as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .uint(bits: 256),
+                                                                 value: 98986565 as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .int(bits: 256),
+                                                                 value: 155445566 as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .address,
+                                                                 value: EthereumAddress("0x9aBbDB06A61cC686BD635484439549D45c2449cc")! as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .bytes(length: 5),
+                                                                 value: "0x9aBbDB06A6" as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .bytes(length: 3),
+                                                                 value: Data.fromHex("0x9aBbDB")! as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .dynamicBytes,
+                                                                 value: Data.fromHex("0x11009aBbDB87879898656545")! as AnyObject),
+                                 Web3.EIP681Code.EIP681Parameter(type: .string,
+                                                                 value: "this is EIP681 query parameter string" as AnyObject)]
+
+        XCTAssertEqual(eip681Link.makeEIP681Link(), "ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc/setData?bytes32[]=[0x1234789565875498655487123478956587549865548712347895658754980000,0x1234789565875498655487123478956587549865548712347895658754986554]&bytes[]=[0x12345607,0x8965abcdef]&uint256=98986565&int256=155445566&address=0x9aBbDB06A61cC686BD635484439549D45c2449cc&bytes5=0x9abbdb06a6&bytes3=0x9abbdb&bytes=0x11009abbdb87879898656545&string=this is EIP681 query parameter string")
+    }
 }

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -5,28 +5,276 @@
 //
 
 import XCTest
+import BigInt
+
 @testable import web3swift
 
 class EIP681Tests: LocalTestCase {
 
-    // Custom payment
-    // ethereum:0xfb6916095ca1df60bb79Ce92ce3ea74c37c5d359?value=2.014e18
+    func testParsing() throws {
+        let testAddress = "0x5ffc014343cd971b7eb70732021e26c35b744cc4"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address.lowercased(), testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
 
-    // ERC20 transfer
-    // ethereum:0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1
-
-    func testEIP681Parsing() async throws {
-        let parsed = await Web3.EIP681CodeParser.parse("ethereum:0x5ffc014343cd971b7eb70732021e26c35b744cc4?value=2.014e18")
-        XCTAssert(parsed != nil)
+        XCTAssertEqual(eip681Code.amount, BigUInt(2014000000000000000))
     }
 
-    func testEIP681Parsing2() async throws {
-        let parsed = await Web3.EIP681CodeParser.parse("ethereum:0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1")
-        XCTAssert(parsed != nil)
+    func testParsingWithEncoding() throws {
+        let testAddress = "0x5ffc014343cd971b7eb70732021e26c35b744cc4"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)?value=2.014e18".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address.lowercased(), testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+        XCTAssertEqual(eip681Code.amount, BigUInt(2014000000000000000))
     }
 
-    func testEIP681ENSParsing() async throws {
-        let parsed = await Web3.EIP681CodeParser.parse("ethereum:somename.eth/transfer?address=somename.eth&uint256=1")
-        XCTAssert(parsed != nil)
+    func testParsing2() throws {
+        let testAddress = "0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[0].value as? EthereumAddress,
+                       EthereumAddress("0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4"))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testParsing2WithEncoding() throws {
+        let testAddress = "0x8932404A197D84Ec3Ea55971AADE11cdA1dddff1"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4&uint256=1"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[0].value as? EthereumAddress,
+                       EthereumAddress("0x6891dC3962e710f0ff711B9c6acc26133Fd35Cb4"))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testENSParsing() throws {
+        let testAddress = "somename.eth"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(_):
+            fatalError("Returned target address cannot be EthereumAddress. It must be ENS address.")
+        case .ensAddress(let address):
+            XCTAssertEqual(address, testAddress)
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        /// `eip681Code.parameters[0].value` is not checked as it's fetched from remote and is unknown.
+        /// `eip681Code.parameters[0].value` must contain some `EthereumAddress`
+        // DO NOT UNCOMMENT, unless you know the exact returned value beforehand.
+        // XCTAssertEqual(eip681Code.parameters[0].value as? String, EthereumAddress(...))
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testENSParsingWithEncoding() throws {
+        let testAddress = "somename.eth"
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)/transfer?address=somename.eth&uint256=1".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(_):
+            fatalError("Returned target address cannot be EthereumAddress. It must be ENS address.")
+        case .ensAddress(let address):
+            XCTAssertEqual(address, testAddress)
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "transfer")
+        XCTAssertEqual(eip681Code.parameters[0].type, .address)
+        /// `eip681Code.parameters[0].value` is not checked as it's fetched from remote and is unknown.
+        /// `eip681Code.parameters[0].value` must contain some `EthereumAddress`
+        // DO NOT UNCOMMENT, unless you know the exact returned value beforehand.
+        // XCTAssertEqual(eip681Code.parameters[0].value as? String, EthereumAddress(...))
+        XCTAssertEqual(eip681Code.parameters[1].type, .uint(bits: 256))
+        XCTAssertEqual(eip681Code.parameters[1].value as? BigUInt, BigUInt(1))
+    }
+
+    func testParsingOfArrayOfBytesAsParameter() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "setData")
+        XCTAssertEqual(eip681Code.function!.signature, "setData(bytes32[],bytes[])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .bytes(length: 32), length: 0))
+
+        var data = eip681Code.parameters[0].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004")!)
+
+        XCTAssertEqual(eip681Code.parameters[1].type, .array(type: .dynamicBytes, length: 0))
+        data = eip681Code.parameters[1].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000038")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000004")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0x005e9F5BB83481d5627aA8c48527C174579bC428")!)
+    }
+
+    func testParsingOfArrayOfBytesAsParameterWithEncoding() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/setData?bytes32[]=[0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428,0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3,0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004]&bytes[]=[0x0000000000000000000000000000000000000000000000000000000000000038,0x0000000000000000000000000000000000000000000000000000000000000004,0x005e9F5BB83481d5627aA8c48527C174579bC428]".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "setData")
+        XCTAssertEqual(eip681Code.function!.signature, "setData(bytes32[],bytes[])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .bytes(length: 32), length: 0))
+        var data = eip681Code.parameters[0].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x4b80742de2bf82acb3630000005e9F5BB83481d5627aA8c48527C174579bC428")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000004")!)
+
+        XCTAssertEqual(eip681Code.parameters[1].type, .array(type: .dynamicBytes, length: 0))
+        data = eip681Code.parameters[1].value as? [Data]
+        XCTAssertEqual(data?[0], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000038")!)
+        XCTAssertEqual(data?[1], Data.fromHex("0x0000000000000000000000000000000000000000000000000000000000000004")!)
+        XCTAssertEqual(data?[2], Data.fromHex("0x005e9F5BB83481d5627aA8c48527C174579bC428")!)
+    }
+
+    func testParsingOfArrayOfIntAsParameter() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[]=[1,2,5000,3,4,10000]")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "functionName123")
+        XCTAssertEqual(eip681Code.function!.signature, "functionName123(int256[])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .int(bits: 256), length: 0))
+        let data = eip681Code.parameters[0].value as? [BigInt]
+        XCTAssertEqual(data, Array<BigInt>(arrayLiteral: 1, 2, 5000, 3, 4, 10000))
+    }
+
+    func testParsingOfArrayOfIntOfFixedLengthAsParameter() throws {
+        let testAddress = "0x9aBbDB06A61cC686BD635484439549D45c2449cc"
+        let chainID = BigUInt(2828)
+        let eip681Code = Web3.EIP681CodeParser.parse("ethereum:\(testAddress)@\(chainID.description)/functionName123?int256[3]=[1,2,5000]")
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+        switch eip681Code.targetAddress {
+        case .ethereumAddress(let address):
+            XCTAssertEqual(address.address, testAddress)
+        case .ensAddress(_):
+            fatalError("Returned target address cannot be ENS address. It must be EthereumAddress.")
+        }
+
+        XCTAssertEqual(eip681Code.functionName, "functionName123")
+        XCTAssertEqual(eip681Code.function!.signature, "functionName123(int256[3])")
+        XCTAssertEqual(eip681Code.chainID, chainID)
+
+        XCTAssertEqual(eip681Code.parameters[0].type, .array(type: .int(bits: 256), length: 3))
+        let data = eip681Code.parameters[0].value as? [BigInt]
+        XCTAssertEqual(data, Array<BigInt>(arrayLiteral: 1, 2, 5000))
+    }
+
+    func testParsingQueryParameterFixedLengthArray() throws {
+        /// Declared `int256[3]` with 2 values instead of expected 3.
+        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2]")
+        XCTAssert(eip681Code != nil)
+        XCTAssert(eip681Code?.parameters.count == 0)
+        /// Declared `int256[3]` with 4 values instead of expected 3.
+        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?int256[3]=[1,2,2,3]")
+        XCTAssert(eip681Code != nil)
+        XCTAssert(eip681Code?.parameters.count == 0)
+    }
+
+    func testParsingQueryParameterStringsArray() throws {
+        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[\"123\",\"2,5000\",\"wwweer2-=!\"]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .string, length: 0))
+        var data = eip681Code!.parameters[0].value as? [String]
+        XCTAssertEqual(data, ["123","2,5000","wwweer2-=!"])
+
+        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[123,2,5000,wwweer2-=!]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .string, length: 0))
+        data = eip681Code!.parameters[0].value as? [String]
+        XCTAssertEqual(data, ["123","2","5000","wwweer2-=!"])
+    }
+
+    func testParsingQueryParameterArrayOfStringsArrays() throws {
+        var eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[\"123\",\"2,5000\",\"wwweer2-=!\"],[\"test1\",\"demo\"]]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .array(type: .string, length: 0), length: 0))
+        var data = eip681Code!.parameters[0].value as? [[String]]
+        XCTAssertEqual(data?[0], ["123","2,5000","wwweer2-=!"])
+        XCTAssertEqual(data?[1], ["test1","demo"])
+
+        eip681Code = Web3.EIP681CodeParser.parse("ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[][]=[[123,2,5000,wwweer2-=!],[test1,demo]]")
+        XCTAssert(eip681Code != nil)
+        guard eip681Code != nil else { return }
+
+        XCTAssertEqual(eip681Code!.parameters[0].type, .array(type: .array(type: .string, length: 0), length: 0))
+        data = eip681Code!.parameters[0].value as? [[String]]
+        XCTAssertEqual(data?[0], ["123","2","5000","wwweer2-=!"])
+        XCTAssertEqual(data?[1], ["test1","demo"])
     }
 }


### PR DESCRIPTION
_Authors:  @JeneaVranceanu, @a-tkchnk_

-----------------------

# The problem

Having EIP681 link like this one:
```
ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828/functionName123?string[]=[123,2,5000,wwweer2-=!]
```

during parsing will result in loss of query parameters and function name and the result would be the following link:
```
ethereum:0x9aBbDB06A61cC686BD635484439549D45c2449cc@2828
```

# What is introduced in this PR?

1) EIP681 parsing of arrays in query parameters. Tuples are not yet handled.
2) Encoding of `EIP681Code.parameters` parameters usable in URL.
3) Added `func makeEIP681Link(urlEncoded: Bool) -> String?` to create EIP681 link from `EIP681Code`. `EIP681Code` structure is used to create an EIP681 URL in a `String` representation with an option to URL encode the EIP681 link before it's returned so it's an actually valid URL.
4) Fixed old test cases for EIP681 and added new ones.

Previously, both `array` and `tuple` types weren't supported during parsing. 
Support for `array` parsing/decoding was added. Covered with multiple test cases.
Support for tuples will come soon.

Also, support for creating a URL (a `String` is actually returned) back from `EIP681Code` instance was added. So now we can create `EIP681Code` by hand, by assigning values to its properties and call `func makeEIP681Link()` to get back a valid URL.  There is still some work to do to support `value`, `gas` and other such parameters in encoding. 
This PR is the first in the sequence of improvements. 