### PR TITLE
[WIP] fix: EIP681 parsing query parameters with extra whitespace characters

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -89,9 +89,23 @@ extension Web3 {
                     return nil
                 }
             }
+
+            if let gasLimit = gasLimit {
+                queryParameters.append("gasLimit=\(gasLimit.description)")
+            }
+
+            if let gasPrice = gasPrice {
+                queryParameters.append("gasPrice=\(gasPrice.description)")
+            }
+
+            if let amount = amount {
+                queryParameters.append("value=\(amount.description)")
+            }
+
             if !queryParameters.isEmpty {
                 link = "\(link)?\(queryParameters.joined(separator: "&"))"
             }
+
             return urlEncode ? link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) : link
         }
     }

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -70,8 +70,9 @@ extension Web3 {
             if let functionName = functionName, !functionName.isEmpty {
                 link = "\(link)/\(functionName)"
             }
+            var queryParameters = [String]()
             if !parameters.isEmpty {
-                let queryParameters: [String] = parameters.compactMap { eip681Parameter in
+                let mappedParameters: [String] = parameters.compactMap { eip681Parameter in
                     guard let queryValue = Web3
                         .EIP681CodeEncoder
                         .encodeFunctionArgument(eip681Parameter.type, eip681Parameter.value)
@@ -81,9 +82,15 @@ extension Web3 {
                     return "\(eip681Parameter.type.abiRepresentation)=\(queryValue)"
                 }
 
-                if queryParameters.count == parameters.count {
-                    link = "\(link)?\(queryParameters.joined(separator: "&"))"
+                if mappedParameters.count == parameters.count {
+                    queryParameters.append(contentsOf: mappedParameters)
+                } else {
+                    NSLog("Failed to map all provided parameters of type `EIP681Parameter`.\nSuccessuflly mapped parameters are: \(mappedParameters.joined(separator: "\n"))")
+                    return nil
                 }
+            }
+            if !queryParameters.isEmpty {
+                link = "\(link)?\(queryParameters.joined(separator: "&"))"
             }
             return urlEncode ? link.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) : link
         }

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -419,7 +419,7 @@ extension Web3 {
                     rawValues = strings
                 } else {
                     let rawValue = String(rawValue.dropFirst().dropLast())
-                    rawValues = rawValue.split(separator: ",").map { String($0) }
+                    rawValues = rawValue.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
                 }
 
                 var nativeValueArray: [AnyObject] = []
@@ -480,7 +480,7 @@ extension Web3 {
                 var prevIndex = 0
                 var result = [String]()
                 for index in indices {
-                    result.append(rawValue[prevIndex..<index])
+                    result.append(rawValue[prevIndex..<index].trimmingCharacters(in: .whitespacesAndNewlines))
                     prevIndex = index + 1
                 }
                 return result

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -361,7 +361,7 @@ extension Web3 {
             }
 
             if code.functionName != nil {
-                /// The number of input values must be excatly the same as the number of query items.
+                /// The number of input values must be exactly the same as the number of query items.
                 /// If at least one is off - it was declared/encoded incorrectly.
                 if inputs.count != queryItems.count {
                     return nil

--- a/Sources/web3swift/Utils/EIP/EIP681.swift
+++ b/Sources/web3swift/Utils/EIP/EIP681.swift
@@ -340,11 +340,20 @@ extension Web3 {
             }
 
             if code.functionName != nil {
+                /// The number of input values must be excatly the same as the number of query items.
+                /// If at least one is off - it was declared/encoded incorrectly.
+                if inputs.count != queryItems.count {
+                    return nil
+                }
+
                 let functionEncoding = ABI.Element.Function(name: code.functionName!, inputs: inputs, outputs: [ABI.Element.InOut](), constant: false, payable: code.amount != nil)
                 code.function = functionEncoding
             }
 
+            #if DEBUG
             print(code)
+            #endif
+
             return code
         }
 

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -353,4 +353,23 @@ class EIP681Tests: XCTestCase {
         let eip681Code = await Web3.EIP681CodeParser.parse(wrongEip681Link)
         XCTAssertNil(eip681Code)
     }
+
+    func testEncodingValueGasLimitAndPrice() async throws {
+        let rawCode = "ethereum:0x5ffc014343cd971b7eb70732021e26c35b744cc4?value=77445123&gasLimit=1234&gasPrice=789456"
+        let eip681Code = await Web3.EIP681CodeParser.parse(rawCode)
+        XCTAssertNotNil(eip681Code)
+        guard let eip681Code = eip681Code else { return }
+        let encodedEip681Link = eip681Code.makeEIP681Link()
+        XCTAssertNotNil(encodedEip681Link)
+        guard let encodedEip681Link = encodedEip681Link,
+              let components = URLComponents(string: encodedEip681Link),
+              let queryItems = components.queryItems else {
+            XCTFail("Failed to parse query items from encoded URL: \(String(describing: encodedEip681Link))")
+            return
+        }
+        let mappedQueryItems = queryItems.map { "\($0.name)=\($0.value ?? "-")" }
+        XCTAssertTrue(mappedQueryItems.contains("gasPrice=789456"))
+        XCTAssertTrue(mappedQueryItems.contains("value=77445123"))
+        XCTAssertTrue(mappedQueryItems.contains("gasLimit=1234"))
+    }
 }

--- a/Tests/web3swiftTests/localTests/EIP681Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP681Tests.swift
@@ -312,4 +312,42 @@ class EIP681Tests: XCTestCase {
         XCTAssertNotNil(encodedOutputLink)
         XCTAssertNotNil(URL(string: encodedOutputLink ?? ""))
     }
+
+
+    func testEIP681ParsingArraysWithWhitespacesIn() async throws {
+        /// This link is constructed in a way that it holds whitespace characters in query parameters in places where
+        /// no such characters should be placed. But it must be decoded correctly.
+        let rawLink = "ethereum:0xAfbd9b509d98a69F8de31932c97CD35bb809CC50@2828/setData?bytes32[]=[0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47 , 0x4b80742de2bf82acb3630000ba99930e9e0bfd77cdc70f9b9656cecc2869e31a  ,      0x4b80742de2bf82acb363000090c650d2c6c5b796c6342118867cbf91f51d8135 , 0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3  ,    0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000000 , 0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000001     , 0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000002 , 0x4b80742de2bf82acb3630000254bfe7e25184f72df435b5a9da39db6089dcaf5 , 0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5]&bytes[]=[0x90c650d2c6c5b796c6342118867cbf91f51d8135 , 0x0000000000000000000000000000000000000000000000000000000000003fbf , 0x0000000000000000000000000000000000000000000000000000000000000008 , 0x0000000000000000000000000000000000000000000000000000000000000003 , 0xba99930e9e0bfd77cdc70f9b9656cecc2869e31a , 0x90c650d2c6c5b796c6342118867cbf91f51d8135 , 0x254bfe7e25184f72df435b5a9da39db6089dcaf5 , 0x0000000000000000000000000000000000000000000000000000000000003fbf , 0x6f357c6a0f079fb3a680e3b3ef2f154772df5f6d345bc052ad733a69bba326f363b6cc30697066733a2f2f516d5042485a4c45686d624c57594e374575505a334b437a735663595a53797544596a59506a7a523342706b6934]"
+        let eip681Code = await Web3.EIP681CodeParser.parse(rawLink)
+        XCTAssert(eip681Code != nil)
+        guard let eip681Code = eip681Code else { return }
+
+        let keys = eip681Code.parameters[0].value as? [Data]
+        let values = eip681Code.parameters[1].value as? [Data]
+        XCTAssertNotNil(keys)
+        XCTAssertNotNil(values)
+
+        guard let keys = keys,
+              let values = values else { return }
+
+        XCTAssertEqual(keys[0].toHexString().addHexPrefix(),"0x0cfc51aec37c55a4d0b1a65c6255c4bf2fbdf6277f3cc0730c45b828b6db8b47")
+        XCTAssertEqual(keys[1].toHexString().addHexPrefix(),"0x4b80742de2bf82acb3630000ba99930e9e0bfd77cdc70f9b9656cecc2869e31a")
+        XCTAssertEqual(keys[2].toHexString().addHexPrefix(),"0x4b80742de2bf82acb363000090c650d2c6c5b796c6342118867cbf91f51d8135")
+        XCTAssertEqual(keys[3].toHexString().addHexPrefix(),"0xdf30dba06db6a30e65354d9a64c609861f089545ca58c6b4dbe31a5f338cb0e3")
+        XCTAssertEqual(keys[4].toHexString().addHexPrefix(), "0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000000")
+        XCTAssertEqual(keys[5].toHexString().addHexPrefix(), "0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000001")
+        XCTAssertEqual(keys[6].toHexString().addHexPrefix(), "0xdf30dba06db6a30e65354d9a64c6098600000000000000000000000000000002")
+        XCTAssertEqual(keys[7].toHexString().addHexPrefix(), "0x4b80742de2bf82acb3630000254bfe7e25184f72df435b5a9da39db6089dcaf5")
+        XCTAssertEqual(keys[8].toHexString().addHexPrefix(), "0x5ef83ad9559033e6e941db7d7c495acdce616347d28e90c7ce47cbfcfcad3bc5")
+
+        XCTAssertEqual(values[0].toHexString().addHexPrefix(), "0x90c650d2c6c5b796c6342118867cbf91f51d8135")
+        XCTAssertEqual(values[1].toHexString().addHexPrefix(), "0x0000000000000000000000000000000000000000000000000000000000003fbf")
+        XCTAssertEqual(values[2].toHexString().addHexPrefix(), "0x0000000000000000000000000000000000000000000000000000000000000008")
+        XCTAssertEqual(values[3].toHexString().addHexPrefix(), "0x0000000000000000000000000000000000000000000000000000000000000003")
+        XCTAssertEqual(values[4].toHexString().addHexPrefix(), "0xba99930e9e0bfd77cdc70f9b9656cecc2869e31a")
+        XCTAssertEqual(values[5].toHexString().addHexPrefix(), "0x90c650d2c6c5b796c6342118867cbf91f51d8135")
+        XCTAssertEqual(values[6].toHexString().addHexPrefix(), "0x254bfe7e25184f72df435b5a9da39db6089dcaf5")
+        XCTAssertEqual(values[7].toHexString().addHexPrefix(), "0x0000000000000000000000000000000000000000000000000000000000003fbf")
+        XCTAssertEqual(values[8].toHexString().addHexPrefix(), "0x6f357c6a0f079fb3a680e3b3ef2f154772df5f6d345bc052ad733a69bba326f363b6cc30697066733a2f2f516d5042485a4c45686d624c57594e374575505a334b437a735663595a53797544596a59506a7a523342706b6934")
+    }
 }


### PR DESCRIPTION
# What was introduced?

1) Corrected parsing of query parameters of EIP681 URL if that parameter is an array and contains whitespace characters between elements, e.g. `ethereum:0x5ffc...4cc4/functionName?bytes2[]=[0xFFFF,  0x0551   ,   0x2200,0x1212]`. White space between items and separators resulted in incorrect decoding.
2) Added encoding of `value`, `gasLimit`, `gasPrice` into the EIP681 when calling `makeEIP681Link() -> String?`.
Example: `ethereum:0x5ffc...4cc4?value=77445123&gasLimit=1234&gasPrice=789456`