### PR TITLE
fix: EIP712 - allow arbitrary EIP712Hashable data models

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP712.swift
+++ b/Sources/web3swift/Utils/EIP/EIP712.swift
@@ -39,10 +39,9 @@ public extension EIP712Hashable {
     }
 
     private func dependencies() -> [EIP712Hashable] {
-        let dependencies = Mirror(reflecting: self).children
+        Mirror(reflecting: self).children
             .compactMap { $0.value as? EIP712Hashable }
             .flatMap { [$0] + $0.dependencies() }
-        return dependencies
     }
 
     private func encodePrimaryType() -> String {

--- a/Sources/web3swift/Utils/EIP/EIP712.swift
+++ b/Sources/web3swift/Utils/EIP/EIP712.swift
@@ -127,7 +127,7 @@ fileprivate extension EIP712Hashable {
             }
             return typeName + " " + key
         }
-        return self.name + "(" + parametrs.joined(separator: ",") + ")"
+        return name + "(" + parametrs.joined(separator: ",") + ")"
     }
 }
 

--- a/Sources/web3swift/Utils/EIP/EIP712.swift
+++ b/Sources/web3swift/Utils/EIP/EIP712.swift
@@ -1,43 +1,7 @@
-import BigInt
 import CryptoSwift
 import Foundation
+import BigInt
 import Core
-
-// TODO: Refactor me
-
-struct EIP712Domain: EIP712DomainHashable {
-    let chainId:            EIP712.UInt256?
-    let verifyingContract:  EIP712.Address
-}
-
-protocol EIP712DomainHashable: EIP712Hashable {}
-
-public struct SafeTx: EIP712Hashable {
-    let to:             EIP712.Address
-    let value:          EIP712.UInt256
-    let data:           EIP712.Bytes
-    let operation:      EIP712.UInt8
-    let safeTxGas:      EIP712.UInt256
-    let baseGas:        EIP712.UInt256
-    let gasPrice:       EIP712.UInt256
-    let gasToken:       EIP712.Address
-    let refundReceiver: EIP712.Address
-    let nonce:          EIP712.UInt256
-
-    public init(to: EIP712.Address, value: EIP712.UInt256, data: EIP712.Bytes, operation: EIP712.UInt8, safeTxGas: EIP712.UInt256, baseGas: EIP712.UInt256, gasPrice: EIP712.UInt256, gasToken: EIP712.Address, refundReceiver: EIP712.Address, nonce: EIP712.UInt256) {
-        self.to = to
-        self.value = value
-        self.data = data
-        self.operation = operation
-        self.safeTxGas = safeTxGas
-        self.baseGas = baseGas
-        self.gasPrice = gasPrice
-        self.gasToken = gasToken
-        self.refundReceiver = refundReceiver
-        self.nonce = nonce
-    }
-
-}
 
 /// Protocol defines EIP712 struct encoding
 public protocol EIP712Hashable {
@@ -50,6 +14,15 @@ public class EIP712 {
     public typealias UInt256 = BigUInt
     public typealias UInt8 = Swift.UInt8
     public typealias Bytes = Data
+}
+
+public struct EIP712Domain: EIP712Hashable {
+    public let chainId:            EIP712.UInt256?
+    public let verifyingContract:  EIP712.Address
+    public init(chainId: EIP712.UInt256?, verifyingContract: EIP712.Address) {
+        self.chainId = chainId
+        self.verifyingContract = verifyingContract
+    }
 }
 
 public extension EIP712.Address {
@@ -114,19 +87,19 @@ public extension EIP712Hashable {
     // MARK: - Default implementation
 
     var typehash: Data {
-        keccak256(encodeType())
+        Data(encodeType().bytes).sha3(.keccak256)
     }
 
     func hash() throws -> Data {
         typealias SolidityValue = (value: Any, type: ABI.Element.ParameterType)
-        var parametrs: [Data] = [self.typehash]
+        var parameters: [Data] = [typehash]
         for case let (_, field) in Mirror(reflecting: self).children {
             let result: Data
             switch field {
             case let string as String:
-                result = keccak256(string)
+                result = Data(string.bytes).sha3(.keccak256)
             case let data as EIP712.Bytes:
-                result = keccak256(data)
+                result = data.sha3(.keccak256)
             case is EIP712.UInt8:
                 result = ABIEncoder.encodeSingleType(type: .uint(bits: 8), value: field as AnyObject)!
             case is EIP712.UInt256:
@@ -143,28 +116,54 @@ public extension EIP712Hashable {
                 }
             }
             guard result.count == 32 else { preconditionFailure("ABI encode error") }
-            parametrs.append(result)
+            parameters.append(result)
         }
-        let encoded = parametrs.flatMap { $0.bytes }
-        return keccak256(encoded)
+        return Data(parameters.flatMap { $0.bytes }).sha3(.keccak256)
     }
 }
 
-// Encode functions
-func eip712encode(domainSeparator: EIP712Hashable, message: EIP712Hashable) throws -> Data {
+public func eip712encode(domainSeparator: EIP712Hashable, message: EIP712Hashable) throws -> Data {
     let data = try Data([UInt8(0x19), UInt8(0x01)]) + domainSeparator.hash() + message.hash()
-    return keccak256(data)
+    return data.sha3(.keccak256)
 }
 
-// MARK: - keccak256
-private func keccak256(_ data: [UInt8]) -> Data {
-    Data(SHA3(variant: .keccak256).calculate(for: data))
-}
+// MARK: - Gnosis Safe Transaction model
 
-private func keccak256(_ string: String) -> Data {
-    keccak256(Array(string.utf8))
-}
+/// Gnosis Safe Transaction.
+/// https://docs.gnosis-safe.io/tutorials/tutorial_tx_service_initiate_sign
+public struct SafeTx: EIP712Hashable {
+    /// Checksummed address
+    let to:             EIP712.Address
+    /// Value in wei
+    let value:          EIP712.UInt256
+    /// 0x prefixed hex string
+    let data:           EIP712.Bytes
+    /// `0` CALL, `1` DELEGATE_CALL
+    let operation:      EIP712.UInt8
+    /// Token address, **must be checksummed**, (held by the Safe) to be used as a refund to the sender, if `null` is Ether
+    let gasToken:       EIP712.Address
+    /// Max gas to use in the transaction
+    let safeTxGas:      EIP712.UInt256
+    /// Gast costs not related to the transaction execution (signature check, refund payment...)
+    let baseGas:        EIP712.UInt256
+    /// Gas price used for the refund calculation
+    let gasPrice:       EIP712.UInt256
+    /// Checksummed address of receiver of gas payment (or `null` if tx.origin)
+    let refundReceiver: EIP712.Address
+    /// Nonce of the Safe, transaction cannot be executed until Safe's nonce is not equal to this nonce
+    let nonce:          EIP712.UInt256
 
-private func keccak256(_ data: Data) -> Data {
-    keccak256(data.bytes)
+    public init(to: EIP712.Address, value: EIP712.UInt256, data: EIP712.Bytes, operation: EIP712.UInt8, safeTxGas: EIP712.UInt256, baseGas: EIP712.UInt256, gasPrice: EIP712.UInt256, gasToken: EIP712.Address, refundReceiver: EIP712.Address, nonce: EIP712.UInt256) {
+        self.to = to
+        self.value = value
+        self.data = data
+        self.operation = operation
+        self.safeTxGas = safeTxGas
+        self.baseGas = baseGas
+        self.gasPrice = gasPrice
+        self.gasToken = gasToken
+        self.refundReceiver = refundReceiver
+        self.nonce = nonce
+    }
+
 }

--- a/Sources/web3swift/Web3/Web3+Signing.swift
+++ b/Sources/web3swift/Web3/Web3+Signing.swift
@@ -31,7 +31,7 @@ public struct Web3Signer {
         return compressedSignature
     }
 
-    public static func signEIP712(safeTx: SafeTx,
+    public static func signEIP712(_ eip712Hashable: EIP712Hashable,
                                   keystore: BIP32Keystore,
                                   verifyingContract: EthereumAddress,
                                   account: EthereumAddress,
@@ -41,7 +41,7 @@ public struct Web3Signer {
         let domainSeparator: EIP712DomainHashable = EIP712Domain(chainId: chainId, verifyingContract: verifyingContract)
 
         let password = password ?? ""
-        let hash = try eip712encode(domainSeparator: domainSeparator, message: safeTx)
+        let hash = try eip712encode(domainSeparator: domainSeparator, message: eip712Hashable)
 
         guard let signature = try Web3Signer.signPersonalMessage(hash, keystore: keystore, account: account, password: password) else {
             throw Web3Error.dataError

--- a/Sources/web3swift/Web3/Web3+Signing.swift
+++ b/Sources/web3swift/Web3/Web3+Signing.swift
@@ -2,7 +2,7 @@
 //  Created by Alex Vlasov.
 //  Copyright © 2018 Alex Vlasov. All rights reserved.
 //
-// Refactor to support EIP-2718 Enveloping by Mark Loit 2022
+//  Refactor to support EIP-2718 Enveloping by Mark Loit 2022
 
 import Foundation
 import BigInt
@@ -27,7 +27,9 @@ public struct Web3Signer {
         var privateKey = try keystore.UNSAFE_getPrivateKeyData(password: password, account: account)
         defer { Data.zero(&privateKey) }
         guard let hash = Utilities.hashPersonalMessage(personalMessage) else { return nil }
-        let (compressedSignature, _) = SECP256K1.signForRecovery(hash: hash, privateKey: privateKey, useExtraEntropy: useExtraEntropy)
+        let (compressedSignature, _) = SECP256K1.signForRecovery(hash: hash,
+                                                                 privateKey: privateKey,
+                                                                 useExtraEntropy: useExtraEntropy)
         return compressedSignature
     }
 
@@ -38,15 +40,15 @@ public struct Web3Signer {
                                   password: String? = nil,
                                   chainId: BigUInt? = nil) throws -> Data {
 
-        let domainSeparator: EIP712DomainHashable = EIP712Domain(chainId: chainId, verifyingContract: verifyingContract)
-
-        let password = password ?? ""
+        let domainSeparator: EIP712Hashable = EIP712Domain(chainId: chainId, verifyingContract: verifyingContract)
         let hash = try eip712encode(domainSeparator: domainSeparator, message: eip712Hashable)
-
-        guard let signature = try Web3Signer.signPersonalMessage(hash, keystore: keystore, account: account, password: password) else {
+        guard let signature = try Web3Signer.signPersonalMessage(hash,
+                                                                 keystore: keystore,
+                                                                 account: account,
+                                                                 password: password ?? "")
+        else {
             throw Web3Error.dataError
         }
-
         return signature
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP712Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP712Tests.swift
@@ -51,7 +51,7 @@ class EIP712Tests: LocalTestCase {
             account: account!,
             password: password,
             chainId: chainId)
-        XCTAssertEqual(signature.toHexString(), "bf3182a3f52e65b416f86e76851c8e7d5602aef28af694f31359705b039d8d1931d53f3d5088ac7195944e8a9188d161ba3757877d08105885304f65282228c71c")
+        XCTAssertEqual(signature.toHexString(), "c0567b120d3de6b3042ae3de1aa346e167454c675e1eaf40ea2f9de89e6a95c2783c1aa6c96aa1e0aaead4ae8901052fa9fd7abe4acb331adafd61610e93c3f01c")
     }
 
     func testWithChainId() throws {
@@ -102,6 +102,6 @@ class EIP712Tests: LocalTestCase {
             account: account!,
             password: password,
             chainId: chainId)
-        XCTAssertEqual(signature.toHexString(), "f1f423cb23efad5035d4fb95c19cfcd46d4091f2bd924680b88c4f9edfa1fb3a4ce5fc5d169f354e3b464f45a425ed3f6203af06afbacdc5c8224a300ce9e6b21b")
+        XCTAssertEqual(signature.toHexString(), "9ee2aadf14739e1cafc3bc1a0b48457c12419d5b480a8ffa86eb7df538c82d0753ca2a6f8024dea576b383cbcbe5e2b181b087e489298674bf6512756cabc5b01b")
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP712Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP712Tests.swift
@@ -4,13 +4,9 @@ import Core
 
 class EIP712Tests: LocalTestCase {
     func testWithoutChainId() throws {
-
         let to = EthereumAddress("0x3F06bAAdA68bB997daB03d91DBD0B73e196c5A4d")!
-
         let value = EIP712.UInt256(0)
-
         let amountLinen = EIP712.UInt256("0001000000000000000")//
-
         let function = ABI.Element.Function(
             name: "approveAndMint",
             inputs: [
@@ -19,28 +15,18 @@ class EIP712Tests: LocalTestCase {
             outputs: [.init(name: "", type: .bool)],
             constant: false,
             payable: false)
-
         let object = ABI.Element.function(function)
-
         let safeTxData = object.encodeParameters([
             EthereumAddress("0x41B5844f4680a8C38fBb695b7F9CFd1F64474a72")! as AnyObject,
             amountLinen as AnyObject
         ])!
-
         let operation: EIP712.UInt8 = 1
-
         let safeTxGas = EIP712.UInt256(250000)
-
         let baseGas = EIP712.UInt256(60000)
-
         let gasPrice = EIP712.UInt256("20000000000")
-
         let gasToken = EthereumAddress("0x0000000000000000000000000000000000000000")!
-        print(1)
         let refundReceiver = EthereumAddress("0x7c07D32e18D6495eFDC487A32F8D20daFBa53A5e")!
-        print(2)
         let nonce: EIP712.UInt256 = .init(6)
-        print(3)
         let safeTX = SafeTx(
             to: to,
             value: value,
@@ -52,38 +38,26 @@ class EIP712Tests: LocalTestCase {
             gasToken: gasToken,
             refundReceiver: refundReceiver,
             nonce: nonce)
-        print(4)
         let password = ""
-        print(5)
         let chainId: EIP712.UInt256? = nil
-        print(6)
         let verifyingContract = EthereumAddress("0x40c21f00Faafcf10Cc671a75ea0de62305199DC1")!
-        print(7)
         let mnemonic = "normal dune pole key case cradle unfold require tornado mercy hospital buyer"
-        print(8)
         let keystore = try! BIP32Keystore(mnemonics: mnemonic, password: "", mnemonicsPassword: "")!
-        print(9)
         let account = keystore.addresses?[0]
-        print(10)
         let signature = try Web3Signer.signEIP712(
-            safeTx: safeTX,
+            safeTX,
             keystore: keystore,
             verifyingContract: verifyingContract,
             account: account!,
             password: password,
             chainId: chainId)
-        print(11)
         XCTAssertEqual(signature.toHexString(), "bf3182a3f52e65b416f86e76851c8e7d5602aef28af694f31359705b039d8d1931d53f3d5088ac7195944e8a9188d161ba3757877d08105885304f65282228c71c")
     }
 
     func testWithChainId() throws {
-
         let to = EthereumAddress("0x3F06bAAdA68bB997daB03d91DBD0B73e196c5A4d")!
-
         let value = EIP712.UInt256(0)
-
         let amount = EIP712.UInt256("0001000000000000000")
-
         let function = ABI.Element.Function(
             name: "approveAndMint",
             inputs: [
@@ -92,28 +66,18 @@ class EIP712Tests: LocalTestCase {
             outputs: [.init(name: "", type: .bool)],
             constant: false,
             payable: false)
-
         let object = ABI.Element.function(function)
-
         let safeTxData = object.encodeParameters([
             EthereumAddress("0x41B5844f4680a8C38fBb695b7F9CFd1F64474a72")! as AnyObject,
             amount as AnyObject
         ])!
-
         let operation: EIP712.UInt8 = 1
-
         let safeTxGas = EIP712.UInt256(250000)
-
         let baseGas = EIP712.UInt256(60000)
-
         let gasPrice = EIP712.UInt256("20000000000")
-
         let gasToken = EthereumAddress("0x0000000000000000000000000000000000000000")!
-
         let refundReceiver = EthereumAddress("0x7c07D32e18D6495eFDC487A32F8D20daFBa53A5e")!
-
         let nonce: EIP712.UInt256 = .init(0)
-
         let safeTX = SafeTx(
             to: to,
             value: value,
@@ -125,24 +89,19 @@ class EIP712Tests: LocalTestCase {
             gasToken: gasToken,
             refundReceiver: refundReceiver,
             nonce: nonce)
-
         let mnemonic = "normal dune pole key case cradle unfold require tornado mercy hospital buyer"
         let keystore = try! BIP32Keystore(mnemonics: mnemonic, password: "", mnemonicsPassword: "")!
-
         let verifyingContract = EthereumAddress("0x76106814dc6150b0fe510fbda4d2d877ac221270")!
-
         let account = keystore.addresses?[0]
         let password  = ""
         let chainId: EIP712.UInt256? = EIP712.UInt256(42)
-
         let signature = try Web3Signer.signEIP712(
-            safeTx: safeTX,
+            safeTX,
             keystore: keystore,
             verifyingContract: verifyingContract,
             account: account!,
             password: password,
             chainId: chainId)
-
         XCTAssertEqual(signature.toHexString(), "f1f423cb23efad5035d4fb95c19cfcd46d4091f2bd924680b88c4f9edfa1fb3a4ce5fc5d169f354e3b464f45a425ed3f6203af06afbacdc5c8224a300ce9e6b21b")
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP712Tests.swift
+++ b/Tests/web3swiftTests/localTests/EIP712Tests.swift
@@ -27,7 +27,7 @@ class EIP712Tests: LocalTestCase {
         let gasToken = EthereumAddress("0x0000000000000000000000000000000000000000")!
         let refundReceiver = EthereumAddress("0x7c07D32e18D6495eFDC487A32F8D20daFBa53A5e")!
         let nonce: EIP712.UInt256 = .init(6)
-        let safeTX = SafeTx(
+        let safeTX = GnosisSafeTx(
             to: to,
             value: value,
             data: safeTxData,
@@ -78,7 +78,7 @@ class EIP712Tests: LocalTestCase {
         let gasToken = EthereumAddress("0x0000000000000000000000000000000000000000")!
         let refundReceiver = EthereumAddress("0x7c07D32e18D6495eFDC487A32F8D20daFBa53A5e")!
         let nonce: EIP712.UInt256 = .init(0)
-        let safeTX = SafeTx(
+        let safeTX = GnosisSafeTx(
             to: to,
             value: value,
             data: safeTxData,


### PR DESCRIPTION
Fix for https://github.com/skywinder/web3swift/issues/617

--------
Function `eip712encode` was built to allow to encode any model that implements `EIP712Hashable` but due to the way it's declared in a project it's not possible to use is. 
The only function aimed at producing EIP-712 compliant signature was `Web3Signer.signEIP712`. This function was correctly with one major flaw - the only message it's able to sign is `struct SafeTx` - the Gnosis Safe Transaction model.

Modifying the message type from `SafeTx` to `EIP712Hashable` was enough to fix the issue.

I decided to go a bit further and clean up `EIP712.swift`.
`SafeTx` was renamed to `GnosisSafeTx`, docs were added to give it more clarity.
Note that renaming `struct SafeTx` led to EIP712 tests failing as class/struct names are used in hashing, thus signatures in EIP712 tests were updated.
