### PR TITLE
fix: ReadOperation data wasn't set and was returned incorrectly

### DIFF
--- a/Sources/web3swift/Operations/ReadTransaction.swift
+++ b/Sources/web3swift/Operations/ReadTransaction.swift
@@ -14,7 +14,7 @@ public class ReadOperation {
     public var transaction: CodableTransaction
     public var contract: EthereumContract
     public var method: String
-    public private (set) var data: Data?
+    public var data: Data? { transaction.data }
 
     var web3: Web3
 


### PR DESCRIPTION
`ReadOperation` class has internal `CodableTransaction`.
`data` property is saved into that `CodableTransaction` thus it must be returned from it as well.
Additionally, no other code in the `ReadOperation` was setting the value for `data`.