### PR TITLE
chore: some clean up of web3 eth calls, comments and tests

### DIFF
--- a/Sources/Core/EthereumABI/ABIDecoding.swift
+++ b/Sources/Core/EthereumABI/ABIDecoding.swift
@@ -17,7 +17,6 @@ extension ABIDecoder {
     }
 
     public static func decode(types: [ABI.Element.ParameterType], data: Data) -> [AnyObject]? {
-        //        print("Full data: \n" + data.toHexString())
         var toReturn = [AnyObject]()
         var consumed: UInt64 = 0
         for i in 0 ..< types.count {
@@ -37,34 +36,26 @@ extension ABIDecoder {
         }
         switch type {
         case .uint(let bits):
-            //            print("Uint256 element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             let mod = BigUInt(1) << bits
             let dataSlice = elementItself[0 ..< 32]
             let v = BigUInt(dataSlice) % mod
-            //            print("Uint256 element is: \n" + String(v))
             return (v as AnyObject, type.memoryUsage)
         case .int(let bits):
-            //            print("Int256 element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             let mod = BigInt(1) << bits
             let dataSlice = elementItself[0 ..< 32]
             let v = BigInt.fromTwosComplement(data: dataSlice) % mod
-            //            print("Int256 element is: \n" + String(v))
             return (v as AnyObject, type.memoryUsage)
         case .address:
-            //            print("Address element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             let dataSlice = elementItself[12 ..< 32]
             let address = EthereumAddress(dataSlice)
-            //            print("Address element is: \n" + String(address.address))
             return (address as AnyObject, type.memoryUsage)
         case .bool:
-            //            print("Bool element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             let dataSlice = elementItself[0 ..< 32]
             let v = BigUInt(dataSlice)
-            //            print("Address element is: \n" + String(v))
             if v == BigUInt(36) ||
                 v == BigUInt(32) ||
                 v == BigUInt(28) ||
@@ -77,34 +68,27 @@ extension ABIDecoder {
                 return (false as AnyObject, type.memoryUsage)
             }
         case .bytes(let length):
-            //            print("Bytes32 element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             let dataSlice = elementItself[0 ..< length]
-            //            print("Bytes32 element is: \n" + String(dataSlice.toHexString()))
             return (dataSlice as AnyObject, type.memoryUsage)
         case .string:
-            //            print("String element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             var dataSlice = elementItself[0 ..< 32]
             let length = UInt64(BigUInt(dataSlice))
             guard elementItself.count >= 32+length else {break}
             dataSlice = elementItself[32 ..< 32 + length]
             guard let string = String(data: dataSlice, encoding: .utf8) else {break}
-            //            print("String element is: \n" + String(string))
             return (string as AnyObject, type.memoryUsage)
         case .dynamicBytes:
-            //            print("Bytes element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             var dataSlice = elementItself[0 ..< 32]
             let length = UInt64(BigUInt(dataSlice))
             guard elementItself.count >= 32+length else {break}
             dataSlice = elementItself[32 ..< 32 + length]
-            //            print("Bytes element is: \n" + String(dataSlice.toHexString()))
             return (dataSlice as AnyObject, type.memoryUsage)
         case .array(type: let subType, length: let length):
             switch type.arraySize {
             case .dynamicSize:
-                //                print("Dynamic array element itself: \n" + elementItself.toHexString())
                 if subType.isStatic {
                     // uint[] like, expect length and elements
                     guard elementItself.count >= 32 else {break}
@@ -130,7 +114,6 @@ extension ABIDecoder {
                     dataSlice = Data(elementItself[32 ..< elementItself.count])
                     var subpointer: UInt64 = 0
                     var toReturn = [AnyObject]()
-                    //                    print("Dynamic array sub element itself: \n" + dataSlice.toHexString())
                     for _ in 0 ..< length {
                         let (v, c) = decodeSingleType(type: subType, data: dataSlice, pointer: subpointer)
                         guard let valueUnwrapped = v, let consumedUnwrapped = c else {break}
@@ -145,7 +128,6 @@ extension ABIDecoder {
                     return (toReturn as AnyObject, nextElementPointer)
                 }
             case .staticSize(let staticLength):
-                //                print("Static array element itself: \n" + elementItself.toHexString())
                 guard length == staticLength else {break}
                 var toReturn = [AnyObject]()
                 var consumed: UInt64 = 0
@@ -164,16 +146,16 @@ extension ABIDecoder {
                 break
             }
         case .tuple(types: let subTypes):
-            //            print("Tuple element itself: \n" + elementItself.toHexString())
             var toReturn = [AnyObject]()
             var consumed: UInt64 = 0
             for i in 0 ..< subTypes.count {
                 let (v, c) = decodeSingleType(type: subTypes[i], data: elementItself, pointer: consumed)
                 guard let valueUnwrapped = v, let consumedUnwrapped = c else {return (nil, nil)}
                 toReturn.append(valueUnwrapped)
-                /*
-                 When decoding a tuple that is not static or an array with a subtype that is not static, the second value in the tuple returned by decodeSignleType is a pointer to the next element, NOT the length of the consumed element. So when decoding such an element, consumed should be set to consumedUnwrapped, NOT incremented by consumedUnwrapped.
-                 */
+                // When decoding a tuple that is not static or an array with a subtype that is not static,
+                // the second value in the tuple returned by decodeSignleType is a pointer to the next element,
+                // NOT the length of the consumed element. So when decoding such an element, consumed should
+                // be set to consumedUnwrapped, NOT incremented by consumedUnwrapped.
                 switch subTypes[i] {
                 case .array(type: let subType, length: _):
                     if !subType.isStatic {
@@ -191,31 +173,24 @@ extension ABIDecoder {
                     consumed = consumed + consumedUnwrapped
                 }
             }
-            //            print("Tuple element is: \n" + String(describing: toReturn))
             if type.isStatic {
                 return (toReturn as AnyObject, consumed)
             } else {
                 return (toReturn as AnyObject, nextElementPointer)
             }
         case .function:
-            //            print("Function element itself: \n" + elementItself.toHexString())
             guard elementItself.count >= 32 else {break}
             let dataSlice = elementItself[8 ..< 32]
-            //            print("Function element is: \n" + String(dataSlice.toHexString()))
             return (dataSlice as AnyObject, type.memoryUsage)
         }
         return (nil, nil)
     }
 
     fileprivate static func followTheData(type: ABI.Element.ParameterType, data: Data, pointer: UInt64 = 0) -> (elementEncoding: Data?, nextElementPointer: UInt64?) {
-        //        print("Follow the data: \n" + data.toHexString())
-        //        print("At pointer: \n" + String(pointer))
         if type.isStatic {
             guard data.count >= pointer + type.memoryUsage else {return (nil, nil)}
             let elementItself = data[pointer ..< pointer + type.memoryUsage]
             let nextElement = pointer + type.memoryUsage
-            //            print("Got element itself: \n" + elementItself.toHexString())
-            //            print("Next element pointer: \n" + String(nextElement))
             return (Data(elementItself), nextElement)
         } else {
             guard data.count >= pointer + type.memoryUsage else {return (nil, nil)}
@@ -237,8 +212,6 @@ extension ABIDecoder {
             let elementPointer = UInt64(bn)
             let elementItself = data[elementPointer ..< UInt64(data.count)]
             let nextElement = pointer + type.memoryUsage
-            //            print("Got element itself: \n" + elementItself.toHexString())
-            //            print("Next element pointer: \n" + String(nextElement))
             return (Data(elementItself), nextElement)
         }
     }

--- a/Sources/Core/EthereumABI/ABIElements.swift
+++ b/Sources/Core/EthereumABI/ABIElements.swift
@@ -194,7 +194,6 @@ extension ABI.Element {
 extension ABI.Element.Constructor {
     public func encodeParameters(_ parameters: [AnyObject]) -> Data? {
         guard parameters.count == inputs.count else { return nil }
-        // FIXME: This should be zipped, because Arrays don't guarantee it's elements order
         return ABIEncoder.encode(types: inputs, values: parameters)
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+Call.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+Call.swift
@@ -10,7 +10,6 @@ import Core
 extension Web3.Eth {
     public func callTransaction(_ transaction: CodableTransaction) async throws -> Data {
         let request: APIRequest = .call(transaction, transaction.callOnBlock ?? .latest)
-        let response: APIResponse<Data> = try await APIRequest.sendRequest(with: self.provider, for: request)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: request).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+EstimateGas.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+EstimateGas.swift
@@ -10,8 +10,6 @@ import Core
 
 extension Web3.Eth {
     public func estimateGas(for transaction: CodableTransaction, onBlock: BlockNumber = .latest) async throws -> BigUInt {
-        let request: APIRequest = .estimateGas(transaction, onBlock)
-        let response: APIResponse<BigUInt> = try await APIRequest.sendRequest(with: provider, for: request)
-        return response.result
+        try await APIRequest.sendRequest(with: provider, for: .estimateGas(transaction, onBlock)).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+FeeHistory.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+FeeHistory.swift
@@ -10,7 +10,6 @@ import Core
 extension Web3.Eth {
     func feeHistory(blockCount: BigUInt, block: BlockNumber, percentiles:[Double]) async throws -> Oracle.FeeHistory {
         let requestCall: APIRequest = .feeHistory(blockCount, block, percentiles)
-        let response: APIResponse<Oracle.FeeHistory> = try await APIRequest.sendRequest(with: web3.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: web3.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetAccounts.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetAccounts.swift
@@ -12,7 +12,6 @@ extension Web3.Eth {
         guard self.web3.provider.attachedKeystoreManager == nil else {
             return try self.web3.wallet.getAccounts()
         }
-        let response: APIResponse<[EthereumAddress]> = try await APIRequest.sendRequest(with: web3.provider, for: .getAccounts)
-        return response.result
+        return try await APIRequest.sendRequest(with: web3.provider, for: .getAccounts).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBalance.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBalance.swift
@@ -10,7 +10,6 @@ import BigInt
 extension Web3.Eth {
     public func getBalance(for address: EthereumAddress, onBlock: BlockNumber = .latest) async throws -> BigUInt {
         let requestCall: APIRequest = .getBalance(address.address, onBlock)
-        let response: APIResponse<BigUInt> = try await APIRequest.sendRequest(with: web3.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: web3.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBlockByHash.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBlockByHash.swift
@@ -12,7 +12,6 @@ extension Web3.Eth {
     public func block(by hash: Data, fullTransactions: Bool = false) async throws -> Block {
         guard let hexString = String(data: hash, encoding: .utf8)?.addHexPrefix() else { throw Web3Error.dataError }
         let requestCall: APIRequest = .getBlockByHash(hash.toHexString().addHexPrefix(), fullTransactions)
-        let response: APIResponse<Block> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBlockByNumber.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBlockByNumber.swift
@@ -11,13 +11,11 @@ import Core
 extension Web3.Eth {
     public func block(by hash: Hash, fullTransactions: Bool = false) async throws -> Block {
         let requestCall: APIRequest = .getBlockByHash(hash, fullTransactions)
-        let response: APIResponse<Block> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: requestCall).result
     }
 
     public func block(by number: BlockNumber, fullTransactions: Bool = false) async throws -> Block {
         let requestCall: APIRequest = .getBlockByNumber(number, fullTransactions)
-        let response: APIResponse<Block> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBlockNumber.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetBlockNumber.swift
@@ -10,7 +10,6 @@ import Core
 
 extension Web3.Eth {
     public func blockNumber() async throws -> BigUInt {
-        let response: APIResponse<BigUInt> = try await APIRequest.sendRequest(with: web3.provider, for: .blockNumber)
-        return response.result
+        try await APIRequest.sendRequest(with: web3.provider, for: .blockNumber).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetCode.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetCode.swift
@@ -9,8 +9,6 @@ import BigInt
 
 extension Web3.Eth { 
     public func code(for address: EthereumAddress, onBlock: BlockNumber = .latest) async throws -> Hash {
-        let requestCall: APIRequest = .getCode(address.address, onBlock)
-        let response: APIResponse<Hash> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        try await APIRequest.sendRequest(with: self.provider, for: .getCode(address.address, onBlock)).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetGasPrice.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetGasPrice.swift
@@ -10,7 +10,6 @@ import Core
 
 extension Web3.Eth {
     public func gasPrice() async throws -> BigUInt {
-        let response: APIResponse<BigUInt> = try await APIRequest.sendRequest(with: self.provider, for: .gasPrice)
-        return response.result
+        try await APIRequest.sendRequest(with: self.provider, for: .gasPrice).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetTransactionCount.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetTransactionCount.swift
@@ -11,7 +11,6 @@ import Core
 extension Web3.Eth {
     public func getTransactionCount(for address: EthereumAddress, onBlock: BlockNumber = .latest) async throws -> BigUInt {
         let requestCall: APIRequest = .getTransactionCount(address.address, onBlock)
-        let response: APIResponse<BigUInt> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetTransactionDetails.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetTransactionDetails.swift
@@ -11,7 +11,6 @@ extension Web3.Eth {
     public func transactionDetails(_ txhash: Data) async throws -> TransactionDetails {
         guard let hexString = String(data: txhash, encoding: .utf8)?.addHexPrefix() else { throw Web3Error.dataError }
         let requestCall: APIRequest = .getTransactionByHash(hexString)
-        let response: APIResponse<TransactionDetails> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetTransactionReceipt.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+GetTransactionReceipt.swift
@@ -11,7 +11,6 @@ extension Web3.Eth {
     public func transactionReceipt(_ txhash: Data) async throws -> TransactionReceipt {
         guard let hexString = String(data: txhash, encoding: .utf8)?.addHexPrefix() else { throw Web3Error.dataError }
         let requestCall: APIRequest = .getTransactionReceipt(hexString)
-        let response: APIResponse<TransactionReceipt> = try await APIRequest.sendRequest(with: self.provider, for: requestCall)
-        return response.result
+        return try await APIRequest.sendRequest(with: self.provider, for: requestCall).result
     }
 }

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+SendRawTransaction.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+SendRawTransaction.swift
@@ -12,9 +12,7 @@ extension Web3.Eth {
         guard let hexString = String(data: data, encoding: .utf8)?.addHexPrefix() else { throw Web3Error.dataError }
         let request: APIRequest = .sendRawTransaction(hexString)
         let response: APIResponse<Hash> = try await APIRequest.sendRequest(with: self.provider, for: request)
-
-        let result = try TransactionSendingResult(data: data, hash: response.result)
-        return result
+        return try TransactionSendingResult(data: data, hash: response.result)
     }
 }
 

--- a/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+SendTransaction.swift
+++ b/Sources/web3swift/EthereumAPICalls/Ethereum/Eth+SendTransaction.swift
@@ -10,13 +10,9 @@ import Core
 
 
 extension Web3.Eth {
-
     public func send(_ transaction: CodableTransaction) async throws -> TransactionSendingResult {
-        // MARK: Sending Data flow
         let request: APIRequest = .sendTransaction(transaction)
         let response: APIResponse<Hash> = try await APIRequest.sendRequest(with: self.provider, for: request)
-
-        let result = TransactionSendingResult(transaction: transaction, hash: response.result)
-        return result
+        return TransactionSendingResult(transaction: transaction, hash: response.result)
     }
 }

--- a/Sources/web3swift/Web3/Web3+Contract.swift
+++ b/Sources/web3swift/Web3/Web3+Contract.swift
@@ -85,7 +85,7 @@ extension Web3 {
         /// Returns a "Transaction intermediate" object.
         public func createReadOperation(_ method: String = "fallback", parameters: [AnyObject] = [AnyObject](), extraData: Data = Data()) -> ReadOperation? {
             // MARK: - Encoding ABI Data flow
-            guard var data = self.contract.method(method, parameters: parameters, extraData: extraData) else { return nil }
+            guard let data = self.contract.method(method, parameters: parameters, extraData: extraData) else { return nil }
 
             transaction.data = data
 
@@ -94,8 +94,7 @@ extension Web3 {
             }
 
             // MARK: Read data from ABI flow
-            let writeTX = ReadOperation.init(transaction: transaction, web3: web3, contract: contract, method: method)
-            return writeTX
+            return .init(transaction: transaction, web3: web3, contract: contract, method: method)
         }
 
         // FIXME: Rewrite this to CodableTransaction
@@ -111,8 +110,7 @@ extension Web3 {
             if let network = self.web3.provider.network {
                 transaction.chainID = network.chainID
             }
-            let writeTX = WriteOperation.init(transaction: transaction, web3: self.web3, contract: self.contract, method: method)
-            return writeTX
+            return .init(transaction: transaction, web3: self.web3, contract: self.contract, method: method)
         }
     }
 }

--- a/Tests/web3swiftTests/localTests/AdvancedABIv2Tests.swift
+++ b/Tests/web3swiftTests/localTests/AdvancedABIv2Tests.swift
@@ -27,7 +27,6 @@ class AdvancedABIv2Tests: LocalTestCase {
         // MARK: Sending Data flow
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 
@@ -64,7 +63,6 @@ class AdvancedABIv2Tests: LocalTestCase {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 
@@ -101,7 +99,6 @@ class AdvancedABIv2Tests: LocalTestCase {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 
@@ -137,7 +134,6 @@ class AdvancedABIv2Tests: LocalTestCase {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 
@@ -174,7 +170,6 @@ class AdvancedABIv2Tests: LocalTestCase {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 

--- a/Tests/web3swiftTests/localTests/BasicLocalNodeTests.swift
+++ b/Tests/web3swiftTests/localTests/BasicLocalNodeTests.swift
@@ -29,7 +29,6 @@ class BasicLocalNodeTests: LocalTestCase {
 
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 
@@ -67,7 +66,6 @@ class BasicLocalNodeTests: LocalTestCase {
 
         let result = try await sendTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 

--- a/Tests/web3swiftTests/localTests/PersonalSignatureTests.swift
+++ b/Tests/web3swiftTests/localTests/PersonalSignatureTests.swift
@@ -44,7 +44,6 @@ class PersonalSignatureTests: XCTestCase {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let deployResult = try await deployTx.writeToChain(password: "web3swift")
         let txHash = deployResult.hash
-        print("Transaction with hash " + txHash)
         
         Thread.sleep(forTimeInterval: 1.0)
         

--- a/Tests/web3swiftTests/localTests/TestHelpers.swift
+++ b/Tests/web3swiftTests/localTests/TestHelpers.swift
@@ -35,7 +35,6 @@ class TestHelpers {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
         
         Thread.sleep(forTimeInterval: 1.0)
         

--- a/Tests/web3swiftTests/localTests/UserCases.swift
+++ b/Tests/web3swiftTests/localTests/UserCases.swift
@@ -82,7 +82,6 @@ class UserCases: XCTestCase {
         deployTx.transaction.gasLimitPolicy = .manual(3000000)
         let result = try await deployTx.writeToChain(password: "web3swift")
         let txHash = result.hash
-        print("Transaction with hash " + txHash)
 
         Thread.sleep(forTimeInterval: 1.0)
 

--- a/Tests/web3swiftTests/remoteTests/InfuraTests.swift
+++ b/Tests/web3swiftTests/remoteTests/InfuraTests.swift
@@ -17,7 +17,7 @@ class InfuraTests: XCTestCase {
             let address = EthereumAddress("0xd61b5ca425F8C8775882d4defefC68A6979DBbce")!
             let balance = try await web3.eth.getBalance(for: address)
             let balString = Utilities.formatToPrecision(balance, numberDecimals: Utilities.Units.eth.decimals, formattingDecimals: 3)
-            print(balString!)
+            XCTAssertNotNil(balString)
         } catch {
             XCTFail()
         }
@@ -26,45 +26,33 @@ class InfuraTests: XCTestCase {
     func testGetBlockByHash() async throws {
         let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
         let result = try await web3.eth.block(by: "0x6d05ba24da6b7a1af22dc6cc2a1fe42f58b2a5ea4c406b19c8cf672ed8ec0695", fullTransactions: false)
-
-        print(result)
     }
     
     func testGetBlockByNumber1() async throws {
         let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
-        let result = try await web3.eth.block(by: .latest, fullTransactions: false)
-        print(result)
+        let _ = try await web3.eth.block(by: .latest, fullTransactions: false)
     }
     
     func testGetBlockByNumber2() async throws {
         let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
-        let result = try await web3.eth.block(by: .exact(5184323), fullTransactions: true)
-        print(result)
-        let transactions = result.transactions
-        for transaction in transactions {
-            switch transaction {
-            case .transaction(let tx):
-                print(String(describing: tx))
-            default:
-                break
-            }
-        }
+        let _ = try await web3.eth.block(by: .exact(5184323), fullTransactions: true)
     }
     
-    func testGetBlockByNumber3() async throws {
+    func testGetBlockByNumber3() async {
+        let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
         do {
-            let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
-            let _ = try await web3.eth.block(by: .exact(1000000000), fullTransactions: true)
-            XCTFail()
+            let _ = try await web3.eth.block(by: .exact(10000000000000), fullTransactions: true)
+            XCTFail("The expression above must throw DecodingError.")
         } catch {
-            
+            // DecodingError is throws as a block for the given block number is
+            // 
+            XCTAssert(error is DecodingError)
         }
     }
     
     func testGasPrice() async throws {
         let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
-        let response = try await web3.eth.gasPrice()
-        print(response)
+        let _ = try await web3.eth.gasPrice()
     }
     
 //    func testGetIndexedEventsPromise() async throws {


### PR DESCRIPTION
- Removed some debugging commented code. You'll never know if you need it again and when, so it's best to use it while developing but not commit it into the repository;
- Reduced the number of lines required for some web3+eth calls;
- Cleaned up a few tests.