### PR TITLE
fix: ERC20 read properties function fixed - multiple inlined async/await was causing issues

### DIFF
--- a/Sources/web3swift/Tokens/ERC20/Web3+ERC20.swift
+++ b/Sources/web3swift/Tokens/ERC20/Web3+ERC20.swift
@@ -181,60 +181,39 @@ protocol ERC20BaseProperties: AnyObject {
     var _decimals: UInt8? { get set }
     var _hasReadProperties: Bool { get set }
     func readProperties() async throws
-    func name() async throws -> String
-    func symbol() async throws -> String
-    func decimals() async throws -> UInt8
+    func name() -> String?
+    func symbol() -> String?
+    func decimals() -> UInt8?
 }
+
 extension ERC20BaseProperties {
-    public func name() async throws -> String {
-        try await self.readProperties()
-        return self._name ?? ""
+    public func name() -> String? {
+        _name
     }
 
-    public func symbol() async throws -> String {
-        try await self.readProperties()
-        return self._symbol ?? ""
+    public func symbol() -> String? {
+        _symbol
     }
 
-    public func decimals() async throws -> UInt8 {
-        try await self.readProperties()
-        return self._decimals ?? 255
+    public func decimals() -> UInt8? {
+        _decimals
     }
 
-    func readProperties() async throws {
-        if self._hasReadProperties {
-            return
-        }
-        let contract = self.contract
+    public func readProperties() async throws {
+        guard !_hasReadProperties else { return }
         guard contract.contract.address != nil else {return}
-        async let namePromise = contract
-            .createReadOperation("name", parameters: [AnyObject](), extraData: Data() )?
-            .callContractMethod()
+        _name = try await contract
+            .createReadOperation("name")?
+            .callContractMethod()["0"] as? String
 
-        async let symbolPromise = try await contract
-            .createReadOperation("symbol", parameters: [AnyObject](), extraData: Data() )?
-            .callContractMethod()
+        _symbol = try await contract
+            .createReadOperation("symbol")?
+            .callContractMethod()["0"] as? String
 
-        async let decimalPromise = try await contract
-            .createReadOperation("decimals", parameters: [AnyObject](), extraData: Data() )?
-            .callContractMethod()
-
-        let resolvedPromises = try await ["name":namePromise, "symbol":symbolPromise, "decimals":decimalPromise]
-
-        if let nameResult = resolvedPromises["name"], let name = nameResult?["0"] as? String {
-            print(name)
-            _name = name
-        }
-
-        if let symbolResult = resolvedPromises["symbol"], let symbol = symbolResult?["0"] as? String {
-            print(symbol)
-            _symbol = symbol
-        }
-
-        if let decimalsResult = resolvedPromises["decimals"], let decimals = decimalsResult?["0"] as? BigUInt {
-            _decimals = UInt8(decimals)
-        }
-
-        self._hasReadProperties = true
+        let decimals = try await contract
+            .createReadOperation("decimals")?
+            .callContractMethod()["0"] as? BigUInt
+        _decimals = decimals != nil ? UInt8(decimals!) : nil
+        _hasReadProperties = true
     }
 }

--- a/Sources/web3swift/Tokens/ST20/Web3+ST20.swift
+++ b/Sources/web3swift/Tokens/ST20/Web3+ST20.swift
@@ -56,15 +56,6 @@ public class ST20: IST20, ERC20BaseProperties {
         self.abi = abi
     }
 
-    // Must be 18!
-    public func decimals() async throws -> UInt8 {
-        try await self.readProperties()
-        if self._decimals != nil {
-            return self._decimals!
-        }
-        return 18
-    }
-
     func tokenDetails() async throws -> [UInt32] {
         let contract = self.contract
         self.transaction.callOnBlock = .latest

--- a/Tests/web3swiftTests/localTests/ERC20Tests.swift
+++ b/Tests/web3swiftTests/localTests/ERC20Tests.swift
@@ -13,10 +13,8 @@ class ERC20Tests: LocalTestCase {
 
     func testERC20name() async throws {
         let (web3, _, receipt, _) = try await TestHelpers.localDeployERC20()
-
-        let parameters = [] as [AnyObject]
         let contract = web3.contract(Web3.Utils.erc20ABI, at: receipt.contractAddress!)!
-        let readTX = contract.createReadOperation("name", parameters:parameters)!
+        let readTX = contract.createReadOperation("name")!
         readTX.transaction.from = EthereumAddress("0xe22b8979739D724343bd002F9f432F5990879901")
         let response = try await readTX.callContractMethod()
         let name = response["0"] as? String

--- a/Tests/web3swiftTests/remoteTests/ST20AndSecurityTokenTests.swift
+++ b/Tests/web3swiftTests/remoteTests/ST20AndSecurityTokenTests.swift
@@ -15,21 +15,15 @@ import Core
 // MARK: Works only with network connection
 class ST20AndSecurityTokenTests: XCTestCase {
 
-    // FIXME: This test fails, it should be fixed in 3.0.1.
-//    func testERC20TokenCreation() async throws {
-//        let web3 = await Web3.InfuraKovanWeb3(accessToken: Constants.infuraToken)
-//        let w3sTokenAddress = EthereumAddress("0x2dD33957C90880bE4Ee9fd5F703110BDA2E579EC")!
-//        let st20token = ST20.init(web3: web3, provider: web3.provider, address: w3sTokenAddress)
-////        try await st20token.readProperties()
-//        let symbol = try await st20token.symbol()
-//        let name = try await st20token.name()
-//        let decimals = try await st20token.decimals()
-//        // FIXME Reading sometimes messes values.
-//        // XCTAssertEqual failed: ("Mimi") is not equal to ("MIMI")
-//        XCTAssertEqual(symbol, "MIMI")
-//        XCTAssertEqual(name, "Mimi")
-//        XCTAssertEqual(decimals, 18)
-//    }
+    func testERC20TokenCreation() async throws {
+        let web3 = await Web3.InfuraKovanWeb3(accessToken: Constants.infuraToken)
+        let w3sTokenAddress = EthereumAddress("0x2dD33957C90880bE4Ee9fd5F703110BDA2E579EC")!
+        let st20token = ST20.init(web3: web3, provider: web3.provider, address: w3sTokenAddress)
+        try await st20token.readProperties()
+        XCTAssertEqual(st20token.symbol(), "MIMI")
+        XCTAssertEqual(st20token.name(), "Mimi")
+        XCTAssertEqual(st20token.decimals(), 18)
+    }
 
     func testST20tokenBalanceAndAllowance() async throws {
         let web3 = await Web3.InfuraKovanWeb3(accessToken: Constants.infuraToken)


### PR DESCRIPTION
This looks like a bug in async/await API. If a similar bug report for Swift isn't found it will be reported.