### PR TITLE
fix: detailed response of parsing EIP4361

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP4361.swift
+++ b/Sources/web3swift/Utils/EIP/EIP4361.swift
@@ -84,17 +84,17 @@ public final class EIP4361 {
     public static func validate(_ message: String) -> EIP4361ValidationResponse {
         let siweConstantMessageRegex = try! NSRegularExpression(pattern: "^\(domain)")
         guard siweConstantMessageRegex.firstMatch(in: message, range: message.fullNSRange) != nil else {
-            return EIP4361ValidationResponse(isEIP4361: false, eip4361: nil, parsedFields: [:])
+            return EIP4361ValidationResponse(isEIP4361: false, eip4361: nil, capturedFields: [:])
         }
 
         let eip4361Regex = try! NSRegularExpression(pattern: eip4361OptionalPattern)
-        var parsedFields: [EIP4361Field: String] = [:]
+        var capturedFields: [EIP4361Field: String] = [:]
         for (key, value) in eip4361Regex.captureGroups(string: message) {
-            parsedFields[.init(rawValue: key)!] = value
+            capturedFields[.init(rawValue: key)!] = value
         }
         return EIP4361ValidationResponse(isEIP4361: true,
                                   eip4361: EIP4361(message),
-                                  parsedFields: parsedFields)
+                                         capturedFields: capturedFields)
     }
 
     /// `domain` is the RFC 3986 authority that is requesting the signing.
@@ -200,7 +200,7 @@ public final class EIP4361 {
 public struct EIP4361ValidationResponse {
     public let isEIP4361: Bool
     public let eip4361: EIP4361?
-    public let parsedFields: [EIP4361.EIP4361Field: String]
+    public let capturedFields: [EIP4361.EIP4361Field: String]
 
     public var isValid: Bool {
         eip4361 != nil

--- a/Sources/web3swift/Utils/EIP/EIP4361.swift
+++ b/Sources/web3swift/Utils/EIP/EIP4361.swift
@@ -82,7 +82,7 @@ public final class EIP4361 {
     }
 
     public static func validate(_ message: String) -> EIP4361ValidationResponse {
-        let siweConstantMessageRegex = try! NSRegularExpression(pattern: "^\(domain)")
+        let siweConstantMessageRegex = try! NSRegularExpression(pattern: "^\(domain)\\n")
         guard siweConstantMessageRegex.firstMatch(in: message, range: message.fullNSRange) != nil else {
             return EIP4361ValidationResponse(isEIP4361: false, eip4361: nil, capturedFields: [:])
         }

--- a/Tests/web3swiftTests/localTests/EIP4361Test.swift
+++ b/Tests/web3swiftTests/localTests/EIP4361Test.swift
@@ -78,10 +78,10 @@ class EIP4361Test: XCTestCase {
         }
 
         XCTAssertNotNil(validationResponse.eip4361)
-        XCTAssertNil(validationResponse.parsedFields[.expirationTime])
-        XCTAssertNil(validationResponse.parsedFields[.notBefore])
-        XCTAssertNil(validationResponse.parsedFields[.requestId])
-        XCTAssertNil(validationResponse.parsedFields[.resources])
+        XCTAssertNil(validationResponse.capturedFields[.expirationTime])
+        XCTAssertNil(validationResponse.capturedFields[.notBefore])
+        XCTAssertNil(validationResponse.capturedFields[.requestId])
+        XCTAssertNil(validationResponse.capturedFields[.resources])
     }
 
     func test_invalidEIP4361_missingAddress() {
@@ -93,7 +93,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.address])
+        XCTAssertNil(validationResponse.capturedFields[.address])
     }
 
     func test_invalidEIP4361_missingUri() {
@@ -105,7 +105,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.uri])
+        XCTAssertNil(validationResponse.capturedFields[.uri])
     }
 
     func test_invalidEIP4361_missingVersion() {
@@ -117,7 +117,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.version])
+        XCTAssertNil(validationResponse.capturedFields[.version])
     }
 
     func test_invalidEIP4361_missingChainId() {
@@ -129,7 +129,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.chainId])
+        XCTAssertNil(validationResponse.capturedFields[.chainId])
     }
 
     func test_invalidEIP4361_missingNonce() {
@@ -141,7 +141,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.nonce])
+        XCTAssertNil(validationResponse.capturedFields[.nonce])
     }
 
     func test_invalidEIP4361_missingIssuedAt() {
@@ -153,7 +153,7 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertNil(validationResponse.parsedFields[.issuedAt])
+        XCTAssertNil(validationResponse.capturedFields[.issuedAt])
     }
 
     func test_invalidEIP4361_wrongVersionNumber() {
@@ -165,6 +165,6 @@ class EIP4361Test: XCTestCase {
             return
         }
 
-        XCTAssertEqual(validationResponse.parsedFields[.version], "123")
+        XCTAssertEqual(validationResponse.capturedFields[.version], "123")
     }
 }

--- a/Tests/web3swiftTests/localTests/EIP4361Test.swift
+++ b/Tests/web3swiftTests/localTests/EIP4361Test.swift
@@ -37,4 +37,134 @@ class EIP4361Test: XCTestCase {
                                                URL(string: "https://example.com/my-web2-claim.json")!])
         XCTAssertEqual(siweMessage.description, rawSiweMessage)
     }
+
+    func test_EIP4361StaticValidationFunc() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+
+        guard validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message.")
+            return
+        }
+
+        let siweMessage = validationResponse.eip4361!
+
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(siweMessage.domain, "service.invalid")
+        XCTAssertEqual(siweMessage.address, EthereumAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")!)
+        XCTAssertEqual(siweMessage.statement, "I accept the ServiceOrg Terms of Service: https://service.invalid/tos")
+        XCTAssertEqual(siweMessage.uri, URL(string: "https://service.invalid/login")!)
+        XCTAssertEqual(siweMessage.version, 1)
+        XCTAssertEqual(siweMessage.chainId, 1)
+        XCTAssertEqual(siweMessage.nonce, "32891756")
+        XCTAssertEqual(siweMessage.issuedAt, dateFormatter.date(from: "2021-09-30T16:25:24.345Z")!)
+        XCTAssertEqual(siweMessage.expirationTime, dateFormatter.date(from: "2021-09-29T15:25:24.234Z")!)
+        XCTAssertEqual(siweMessage.notBefore, dateFormatter.date(from: "2021-10-28T14:25:24.123Z")!)
+        XCTAssertEqual(siweMessage.requestId, "random-request-id_STRING!@$%%&")
+        XCTAssertEqual(siweMessage.resources, [URL(string: "ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/")!,
+                                               URL(string: "https://example.com/my-web2-claim.json")!])
+        XCTAssertEqual(siweMessage.description, rawSiweMessage)
+    }
+
+    func test_validEIP4361_noOptionalFields() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isValid else {
+            XCTFail("Failed to parse valid SIWE message.")
+            return
+        }
+
+        XCTAssertNotNil(validationResponse.eip4361)
+        XCTAssertNil(validationResponse.parsedFields[.expirationTime])
+        XCTAssertNil(validationResponse.parsedFields[.notBefore])
+        XCTAssertNil(validationResponse.parsedFields[.requestId])
+        XCTAssertNil(validationResponse.parsedFields[.resources])
+    }
+
+    func test_invalidEIP4361_missingAddress() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:I accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.address])
+    }
+
+    func test_invalidEIP4361_missingUri() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.uri])
+    }
+
+    func test_invalidEIP4361_missingVersion() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.version])
+    }
+
+    func test_invalidEIP4361_missingChainId() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.chainId])
+    }
+
+    func test_invalidEIP4361_missingNonce() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.nonce])
+    }
+
+    func test_invalidEIP4361_missingIssuedAt() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertNil(validationResponse.parsedFields[.issuedAt])
+    }
+
+    func test_invalidEIP4361_wrongVersionNumber() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\n0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2\n\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 123\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Failed to parse SIWE message. isEIP4361 must be `true` but the SIWE must be invalid.")
+            return
+        }
+
+        XCTAssertEqual(validationResponse.parsedFields[.version], "123")
+    }
 }

--- a/Tests/web3swiftTests/localTests/EIP4361Test.swift
+++ b/Tests/web3swiftTests/localTests/EIP4361Test.swift
@@ -85,7 +85,7 @@ class EIP4361Test: XCTestCase {
     }
 
     func test_invalidEIP4361_missingAddress() {
-        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:I accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\nI accept the ServiceOrg Terms of Service: https://service.invalid/tos\n\nURI: https://service.invalid/login\nVersion: 1\nChain ID: 1\nNonce: 32891756\nIssued At: 2021-09-30T16:25:24.345Z\nExpiration Time: 2021-09-29T15:25:24.234Z\nNot Before: 2021-10-28T14:25:24.123Z\nRequest ID: random-request-id_STRING!@$%%&\nResources:\n- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/\n- https://example.com/my-web2-claim.json"
 
         let validationResponse = EIP4361.validate(rawSiweMessage)
         guard validationResponse.isEIP4361 && !validationResponse.isValid else {


### PR DESCRIPTION
Enhanced EIP4361 feature: `EIP4361.validate(...)` returns validation object that holds:
- `isEIP4361` flag that tells if the message given for validation represents EIP4361;
- `isValid` - tells if EIP4361 message is meeting all requirements;
- optional `EIP4361` that is safe to force unwrap if `isValid` equals `true`;
- a dictionary of all successfully extracted (not parsed) fields with raw values for each field. Values are accessed by a new enum `EIP4361Field`.

This combination allows getting the reason for failed message parsing, e.g. if `capturedFields` does not contain value for `EIP4361Field.address` it's safe to assume that message does not contain the address field which is required.

<img width="1038" alt="Снимок экрана 2022-09-30 в 09 27 09" src="https://user-images.githubusercontent.com/36865532/193272548-b8b5e853-43aa-42e4-aa58-3f0eca03feee.png">

<img width="1159" alt="Снимок экрана 2022-09-29 в 22 12 31" src="https://user-images.githubusercontent.com/36865532/193272591-0549d53a-8868-43fe-b910-053a03beec5f.png">
