### PR TITLE
fix: EIP4361 - improved validation by adding ability to extract invalid values for all fields

### DIFF
--- a/Sources/web3swift/Utils/EIP/EIP4361.swift
+++ b/Sources/web3swift/Utils/EIP/EIP4361.swift
@@ -77,8 +77,37 @@ public final class EIP4361 {
         "^\(domain)\(address)\(statementParagraph)\(uri)\(version)\(chainId)\(nonce)\(issuedAt)\(expirationTime)\(notBefore)\(requestId)\(resourcesParagraph)$"
     }
 
+    private static var _eip4361OptionalPattern: String!
     private static var eip4361OptionalPattern: String {
-        "^\(domain)(\(address))?\(statementParagraph)(\(uri))?(\(version))?(\(chainId))?(\(nonce))?(\(issuedAt))?\(expirationTime)\(notBefore)\(requestId)\(resourcesParagraph)$"
+        guard _eip4361OptionalPattern == nil else { return _eip4361OptionalPattern! }
+
+        let domain = "(?<\(EIP4361Field.domain.rawValue)>(.*)) wants you to sign in with your Ethereum account:"
+        let address = "\\n(?<\(EIP4361Field.address.rawValue)>.*)\\n\\n"
+        let uri = "\\nURI: (?<\(EIP4361Field.uri.rawValue)>(.*)?)"
+        let version = "\\nVersion: (?<\(EIP4361Field.version.rawValue)>.*)"
+        let chainId = "\\nChain ID: (?<\(EIP4361Field.chainId.rawValue)>.*)"
+        let nonce = "\\nNonce: (?<\(EIP4361Field.nonce.rawValue)>.*)"
+        let issuedAt = "\\nIssued At: (?<\(EIP4361Field.issuedAt.rawValue)>(.*))"
+        let expirationTime = "(\\nExpiration Time: (?<\(EIP4361Field.expirationTime.rawValue)>(.*)))?"
+        let notBefore = "(\\nNot Before: (?<\(EIP4361Field.notBefore.rawValue)>(.*)))?"
+        let requestId = "(\\nRequest ID: (?<\(EIP4361Field.requestId.rawValue)>.*))?"
+        let resourcesParagraph = "(\\nResources:(?<\(EIP4361Field.resources.rawValue)>(.|\n)*))?"
+
+        let patternParts: [String] = ["^\(domain)",
+                                      "(\(address))?",
+                                      "\(statementParagraph)",
+                                      "(\(uri))?",
+                                      "(\(version))?",
+                                      "(\(chainId))?",
+                                      "(\(nonce))?",
+                                      "(\(issuedAt))?",
+                                      "\(expirationTime)",
+                                      "\(notBefore)",
+                                      "\(requestId)",
+                                      "\(resourcesParagraph)$"]
+
+        _eip4361OptionalPattern = patternParts.joined()
+        return _eip4361OptionalPattern!
     }
 
     public static func validate(_ message: String) -> EIP4361ValidationResponse {

--- a/Tests/web3swiftTests/localTests/EIP4361Test.swift
+++ b/Tests/web3swiftTests/localTests/EIP4361Test.swift
@@ -167,4 +167,27 @@ class EIP4361Test: XCTestCase {
 
         XCTAssertEqual(validationResponse.capturedFields[.version], "123")
     }
+
+    func test_validEIP4361_allRequiredFieldsContainWrongData() {
+        let rawSiweMessage = "service.invalid wants you to sign in with your Ethereum account:\nnot-a-hex-1234567890qwertyuiop1234567890qwertyuiop\n\nTHESTATEMENT123102938102938: aURIisSupposedToBeHEre\n\nURI: ANOTHER_URIisSupposedToBeHEre\nVersion: dsfjlsdafhjalsdfjh\nChain ID: not-a-chain-id\nNonce: not a nonce\nIssued At: this-is-not-a-date\nExpiration Time: expiration-time-not-a-date\nNot Before: not-before-not-a-date\nRequest ID: random-request-id_STRING!@$%%&\nResources:noURLSreallyHERE"
+
+        let validationResponse = EIP4361.validate(rawSiweMessage)
+        guard validationResponse.isEIP4361 && !validationResponse.isValid else {
+            XCTFail("Must not be able to parse this SIWE message.")
+            return
+        }
+
+        XCTAssertEqual(validationResponse.capturedFields[.domain], "service.invalid")
+        XCTAssertEqual(validationResponse.capturedFields[.address], "not-a-hex-1234567890qwertyuiop1234567890qwertyuiop")
+        XCTAssertEqual(validationResponse.capturedFields[.statement], "THESTATEMENT123102938102938: aURIisSupposedToBeHEre")
+        XCTAssertEqual(validationResponse.capturedFields[.uri], "ANOTHER_URIisSupposedToBeHEre")
+        XCTAssertEqual(validationResponse.capturedFields[.version], "dsfjlsdafhjalsdfjh")
+        XCTAssertEqual(validationResponse.capturedFields[.chainId], "not-a-chain-id")
+        XCTAssertEqual(validationResponse.capturedFields[.nonce], "not a nonce")
+        XCTAssertEqual(validationResponse.capturedFields[.issuedAt], "this-is-not-a-date")
+        XCTAssertEqual(validationResponse.capturedFields[.expirationTime], "expiration-time-not-a-date")
+        XCTAssertEqual(validationResponse.capturedFields[.notBefore], "not-before-not-a-date")
+        XCTAssertEqual(validationResponse.capturedFields[.requestId], "random-request-id_STRING!@$%%&")
+        XCTAssertEqual(validationResponse.capturedFields[.resources], "noURLSreallyHERE")
+    }
 }


### PR DESCRIPTION
This PR includes regular expression fixes for extraction of all fields that could be present in EIP4361.
Regular expressions are duplicated and modified to support the extraction of any characters present for each individual field.
That allows us to get the idea of what is wrong with the EIP4361, what fields have and don't have any values set and which values are invalid.