### PR TITLE
feat: added support for JSON RPC Error object

### DIFF
--- a/Sources/Core/EthereumNetwork/Request/APIRequest+Methods.swift
+++ b/Sources/Core/EthereumNetwork/Request/APIRequest+Methods.swift
@@ -34,10 +34,24 @@ extension APIRequest {
             }
         }
 
+        if let error = (try? JSONDecoder().decode(JsonRpcErrorObject.self, from: data))?.error {
+            guard let parsedErrorCode = error.parsedErrorCode else {
+                throw Web3Error.nodeError(desc: "\(error.message)\nError code: \(error.code)")
+            }
+            let description = "\(parsedErrorCode.errorName). Error code: \(error.code). \(error.message)"
+            switch parsedErrorCode {
+            case .parseError, .invalidParams:
+                throw Web3Error.inputError(desc: description)
+            case .methodNotFound, .invalidRequest:
+                throw Web3Error.processingError(desc: description)
+            case .internalError, .serverError:
+                throw Web3Error.nodeError(desc: description)
+            }
+        }
+
         /// This bit of code is purposed to work with literal types that comes in ``Response`` in hexString type.
         /// Currently it's just `Data` and any kind of Integers `(U)Int`, `Big(U)Int`.
-        if Result.self == Data.self || Result.self == UInt.self || Result.self == Int.self || Result.self == BigInt.self || Result.self == BigUInt.self {
-            guard let LiteralType = Result.self as? LiteralInitiableFromString.Type else { throw Web3Error.typeError }
+        if let LiteralType = Result.self as? LiteralInitiableFromString.Type {
             guard let responseAsString = try? JSONDecoder().decode(APIResponse<String>.self, from: data) else { throw Web3Error.dataError }
             guard let literalValue = LiteralType.init(from: responseAsString.result) else { throw Web3Error.dataError }
             /// `literalValue` conforms `LiteralInitiableFromString`, that conforming to an `APIResponseType` type, so it's never fails.
@@ -45,5 +59,78 @@ extension APIRequest {
             return APIResponse(id: responseAsString.id, jsonrpc: responseAsString.jsonrpc, result: result)
         }
         return try JSONDecoder().decode(APIResponse<Result>.self, from: data)
+    }
+}
+
+/// JSON RPC Error object. See official specification https://www.jsonrpc.org/specification#error_object
+fileprivate struct JsonRpcErrorObject: Decodable {
+    public let error: RpcError?
+
+    class RpcError: Decodable {
+        let message: String
+        let code: Int
+        var parsedErrorCode: JsonRpcErrorCode? {
+            JsonRpcErrorCode.from(code)
+        }
+    }
+}
+
+/// For error codes specification see chapter `5.1 Error object`
+/// https://www.jsonrpc.org/specification#error_object
+fileprivate enum JsonRpcErrorCode {
+    /// -32700
+    /// Invalid JSON was received by the server. An error occurred on the server while parsing the JSON
+    case parseError
+    /// -32600
+    /// The JSON sent is not a valid Request object.
+    case invalidRequest
+    /// -32601
+    /// The method does not exist / is not available.
+    case methodNotFound
+    /// -32602
+    /// Invalid method parameter(s).
+    case invalidParams
+    /// -32603
+    /// Internal JSON-RPC error.
+    case internalError
+    /// Values in range of -32000 to -32099
+    /// Reserved for implementation-defined server-errors.
+    case serverError(Int)
+
+    var errorName: String {
+        switch self {
+        case .parseError:
+            return "Parsing error"
+        case .invalidRequest:
+            return "Invalid request"
+        case .methodNotFound:
+            return "Method not found"
+        case .invalidParams:
+            return "Invalid parameters"
+        case .internalError:
+            return "Internal error"
+        case .serverError(_):
+            return "Server error"
+        }
+    }
+
+    static func from(_ code: Int) -> JsonRpcErrorCode? {
+        switch code {
+        case -32700:
+            return .parseError
+        case -32600:
+            return .invalidRequest
+        case -32601:
+            return .methodNotFound
+        case -32602:
+            return .invalidParams
+        case -32603:
+            return .internalError
+        default:
+            if (-32000)...(-32099) ~= code {
+                return .serverError(code)
+            }
+            return nil
+        }
     }
 }


### PR DESCRIPTION
If there is an error during the execution of a JSON RPC request we may receive a response containing the error information.
See JSON Error object specification: https://www.jsonrpc.org/specification#error_object

Here is an example of an error before:

<img width="1065" alt="Screenshot 2022-10-09 at 10 26 03" src="https://user-images.githubusercontent.com/36865532/194749449-b24730f4-dfa5-41b5-b7fa-75f161dfb0b3.png">


And here is the same error after error object parsing was added:

<img width="1062" alt="Screenshot 2022-10-09 at 10 26 38" src="https://user-images.githubusercontent.com/36865532/194749481-6d9a79d4-9ace-4755-b83e-1dde5d901179.png">
