### PR TITLE
Fix range of JsonRpcErrorCode

### DIFF
--- a/Sources/Core/EthereumNetwork/Request/APIRequest+Methods.swift
+++ b/Sources/Core/EthereumNetwork/Request/APIRequest+Methods.swift
@@ -127,7 +127,7 @@ fileprivate enum JsonRpcErrorCode {
         case -32603:
             return .internalError
         default:
-            if (-32000)...(-32099) ~= code {
+            if (-32099)...(-32000) ~= code {
                 return .serverError(code)
             }
             return nil


### PR DESCRIPTION
Fixes range of server error check - as otherwise this condition will throw `Fatal error: Range requires lowerBound <= upperBound`.

