### PR TITLE
Add tests for EIP1559 transactions on Mainnet and Goerli

### DIFF
--- a/Tests/web3swiftTests/remoteTests/EIP1559Tests.swift
+++ b/Tests/web3swiftTests/remoteTests/EIP1559Tests.swift
@@ -25,7 +25,7 @@ final class EIP1559Tests: XCTestCase {
         tx.from = EthereumAddress("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")!
         // Should fail if there would be something wrong with the tx
         let res = try await web3.eth.estimateGas(for: tx)
-        XCTAssertTrue(res > 0)
+        XCTAssertGreaterThan(res, 0)
     }
 
     func testEIP1159GoerliTransaction() async throws {
@@ -41,7 +41,7 @@ final class EIP1559Tests: XCTestCase {
         tx.from = EthereumAddress("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")!
         // Should fail if there would be something wrong with the tx
         let res = try await web3.eth.estimateGas(for: tx)
-        XCTAssertTrue(res > 0)
+        XCTAssertGreaterThan(res, 0)
     }
 
 }

--- a/Tests/web3swiftTests/remoteTests/EIP1559Tests.swift
+++ b/Tests/web3swiftTests/remoteTests/EIP1559Tests.swift
@@ -1,0 +1,47 @@
+//
+//  EIP1559Tests.swift
+//  
+//
+//  Created by Jann Driessen on 01.11.22.
+//
+
+import XCTest
+import Core
+
+@testable import web3swift
+
+final class EIP1559Tests: XCTestCase {
+
+    func testEIP1159MainnetTransaction() async throws {
+        let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
+        var tx = CodableTransaction(
+            type: .eip1559,
+            to: EthereumAddress("0xb47292B7bBedA4447564B8336E4eD1f93735e7C7")!,
+            chainID: web3.provider.network!.chainID,
+            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            gasLimit: 21_000
+        )
+        // Vitalik's address
+        tx.from = EthereumAddress("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")!
+        // Should fail if there would be something wrong with the tx
+        let res = try await web3.eth.estimateGas(for: tx)
+        XCTAssertTrue(res > 0)
+    }
+
+    func testEIP1159GoerliTransaction() async throws {
+        let web3 = await Web3.InfuraGoerliWeb3(accessToken: Constants.infuraToken)
+        var tx = CodableTransaction(
+            type: .eip1559,
+            to: EthereumAddress("0xeBec795c9c8bBD61FFc14A6662944748F299cAcf")!,
+            chainID: web3.provider.network!.chainID,
+            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            gasLimit: 21_000
+        )
+        // Vitalik's address
+        tx.from = EthereumAddress("0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B")!
+        // Should fail if there would be something wrong with the tx
+        let res = try await web3.eth.estimateGas(for: tx)
+        XCTAssertTrue(res > 0)
+    }
+
+}


### PR DESCRIPTION
Adds tests for EIP1559 transactions on Mainnet and Goerli - to verify that transaction configurations work when sending ether.

[Discussed on Discord](https://discord.com/channels/852230666292559882/855075850771496971/1034863420018798653).